### PR TITLE
Mzlib update

### DIFF
--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -25,7 +25,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="mzLib" Version="1.0.485" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
+    <PackageReference Include="TopDownProteomics" Version="0.0.287" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -5,18 +5,10 @@
     <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
-    <Platforms>AnyCPU;x64</Platforms>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -2,16 +2,25 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/Engine/GlobalVariables.cs
+++ b/Engine/GlobalVariables.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using UsefulProteomicsDatabases;
+using TopDownProteomics.IO.Obo;
 
 namespace Engine
 {

--- a/Engine/GlobalVariables.cs
+++ b/Engine/GlobalVariables.cs
@@ -103,7 +103,6 @@ namespace Engine
 
         // File locations
         public static string DataDir { get; }
-
         public static bool StopLoops { get; set; }
         public static string ElementsLocation { get; }
         public static string ProteaseGuruVersion { get; }        

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="mzLib" Version="1.0.485" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -5,22 +5,14 @@
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Icons\proteaseGuru.ico</ApplicationIcon>
-    <Platforms>AnyCPU;x64</Platforms>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>   
     <None Remove="proteaseGuru.ico" /> 
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Icons\proteaseGuru.ico</ApplicationIcon>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>   
@@ -15,7 +16,15 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/ProteaseGuru.sln
+++ b/ProteaseGuru.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29728.190
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33712.159
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GUI", "GUI\GUI.csproj", "{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}"
 EndProject
@@ -9,30 +9,48 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tasks", "Tasks\Tasks.csproj
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Engine", "Engine\Engine.csproj", "{0401D402-DD1F-4492-9871-A3A514081471}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test", "Test\Test.csproj", "{D21C3C88-E27A-47D2-9A93-CE156B46F566}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test", "Test\Test.csproj", "{D21C3C88-E27A-47D2-9A93-CE156B46F566}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Debug|x64.ActiveCfg = Debug|x64
+		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Debug|x64.Build.0 = Debug|x64
 		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Release|x64.ActiveCfg = Release|x64
+		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Release|x64.Build.0 = Release|x64
 		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Debug|x64.ActiveCfg = Debug|x64
+		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Debug|x64.Build.0 = Debug|x64
 		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Release|x64.ActiveCfg = Release|x64
+		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Release|x64.Build.0 = Release|x64
 		{0401D402-DD1F-4492-9871-A3A514081471}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0401D402-DD1F-4492-9871-A3A514081471}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0401D402-DD1F-4492-9871-A3A514081471}.Debug|x64.ActiveCfg = Debug|x64
+		{0401D402-DD1F-4492-9871-A3A514081471}.Debug|x64.Build.0 = Debug|x64
 		{0401D402-DD1F-4492-9871-A3A514081471}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0401D402-DD1F-4492-9871-A3A514081471}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0401D402-DD1F-4492-9871-A3A514081471}.Release|x64.ActiveCfg = Release|x64
+		{0401D402-DD1F-4492-9871-A3A514081471}.Release|x64.Build.0 = Release|x64
 		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Debug|x64.ActiveCfg = Debug|x64
+		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Debug|x64.Build.0 = Debug|x64
 		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Release|x64.ActiveCfg = Release|x64
+		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ProteaseGuru.sln
+++ b/ProteaseGuru.sln
@@ -13,42 +13,24 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test", "Test\Test.csproj", 
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
-		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Debug|x64.ActiveCfg = Debug|x64
 		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Debug|x64.Build.0 = Debug|x64
-		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Release|x64.ActiveCfg = Release|x64
 		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Release|x64.Build.0 = Release|x64
-		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Debug|x64.ActiveCfg = Debug|x64
 		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Debug|x64.Build.0 = Debug|x64
-		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Release|x64.ActiveCfg = Release|x64
 		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Release|x64.Build.0 = Release|x64
-		{0401D402-DD1F-4492-9871-A3A514081471}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0401D402-DD1F-4492-9871-A3A514081471}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0401D402-DD1F-4492-9871-A3A514081471}.Debug|x64.ActiveCfg = Debug|x64
 		{0401D402-DD1F-4492-9871-A3A514081471}.Debug|x64.Build.0 = Debug|x64
-		{0401D402-DD1F-4492-9871-A3A514081471}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0401D402-DD1F-4492-9871-A3A514081471}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0401D402-DD1F-4492-9871-A3A514081471}.Release|x64.ActiveCfg = Release|x64
 		{0401D402-DD1F-4492-9871-A3A514081471}.Release|x64.Build.0 = Release|x64
-		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Debug|x64.ActiveCfg = Debug|x64
 		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Debug|x64.Build.0 = Debug|x64
-		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Release|x64.ActiveCfg = Release|x64
 		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection

--- a/Tasks/Tasks.csproj
+++ b/Tasks/Tasks.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="mzLib" Version="1.0.485" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>
 

--- a/Tasks/Tasks.csproj
+++ b/Tasks/Tasks.csproj
@@ -5,18 +5,10 @@
     <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
-    <Platforms>AnyCPU;x64</Platforms>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/Tasks/Tasks.csproj
+++ b/Tasks/Tasks.csproj
@@ -2,16 +2,25 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="mzLib" Version="1.0.485" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -3,18 +3,10 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <Platforms>AnyCPU;x64</Platforms>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -2,14 +2,23 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.102",
+    "version": "6.0.402",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
user requested new feature. that may come in a future PR. For now, I wanted to update PG for the latest version of mzlib. This PR does that. In addition, I changed the target framework from .netcore 3.1 to .net 6, which is where we have mzlib and metamorepheus currently. Last change was to move from Any CPU to x64. We have done this for mzlib and metamorpheus (I think). This appears to run on my machine and the tests pass.