### PR TITLE
Add pepsin and papain proteases

### DIFF
--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -25,7 +25,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="mzLib" Version="1.0.485" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
+    <PackageReference Include="TopDownProteomics" Version="0.0.287" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -5,18 +5,10 @@
     <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
-    <Platforms>AnyCPU;x64</Platforms>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -2,16 +2,25 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/Engine/GlobalVariables.cs
+++ b/Engine/GlobalVariables.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using UsefulProteomicsDatabases;
+using TopDownProteomics.IO.Obo;
 
 namespace Engine
 {

--- a/Engine/GlobalVariables.cs
+++ b/Engine/GlobalVariables.cs
@@ -103,7 +103,6 @@ namespace Engine
 
         // File locations
         public static string DataDir { get; }
-
         public static bool StopLoops { get; set; }
         public static string ElementsLocation { get; }
         public static string ProteaseGuruVersion { get; }        

--- a/Engine/ProteolyticDigestion/proteases.tsv
+++ b/Engine/ProteolyticDigestion/proteases.tsv
@@ -9,8 +9,8 @@ Glu-C (with asp)	"E|,D|"			full
 Lys-C (don't cleave before proline)	K[P]|			full	MS:1001309	Lys-C	(?<=K)(?!P)		
 Lys-C (cleave before proline)	K|			full	MS:1001310	Lys-C/P	(?<=K)		
 Lys-N	|K			full					
-pepsin	"F|,L|,Y|,W|"			full
-papain	"L|,G|"			full
+pepsin	"F|,L|,Y|,W|"			full				
+papain	"L|,G|"			full				
 trypsin (cleave before proline)	"K|,R|"			full	MS:1001313	Trypsin/P	(?<=[KR])		
 trypsin (don't cleave before proline)	"K[P]|,R[P]|"			full	MS:1001251	Trypsin	(?<=[KR])(?!P) 		
 collagenase	GPX|GPX			full					

--- a/Engine/ProteolyticDigestion/proteases.tsv
+++ b/Engine/ProteolyticDigestion/proteases.tsv
@@ -9,6 +9,8 @@ Glu-C (with asp)	"E|,D|"			full
 Lys-C (don't cleave before proline)	K[P]|			full	MS:1001309	Lys-C	(?<=K)(?!P)		
 Lys-C (cleave before proline)	K|			full	MS:1001310	Lys-C/P	(?<=K)		
 Lys-N	|K			full					
+pepsin	"F|,L|,Y|,W|"			full
+papain	"L|,G|"			full
 trypsin (cleave before proline)	"K|,R|"			full	MS:1001313	Trypsin/P	(?<=[KR])		
 trypsin (don't cleave before proline)	"K[P]|,R[P]|"			full	MS:1001251	Trypsin	(?<=[KR])(?!P) 		
 collagenase	GPX|GPX			full					

--- a/GUI/CustomProteaseWindow.xaml
+++ b/GUI/CustomProteaseWindow.xaml
@@ -21,7 +21,7 @@
                             <Style.Resources>
                                 <VisualBrush x:Key="CueBannerBrush" AlignmentX="Left" AlignmentY="Center" Stretch="None">
                                     <VisualBrush.Visual>
-                                        <Label Content="ex: 'trypsin'" Foreground="Gray" />
+                                        <Label Content="trypsin" Foreground="Gray" />
                                     </VisualBrush.Visual>
                                 </VisualBrush>
                             </Style.Resources>
@@ -44,16 +44,16 @@
             <StackPanel Orientation="Horizontal">
                 <Label Content="Sequences Inducing Cleavage" Width="180" Style="{StaticResource xSmallHeaderLabelStyle}"></Label>
                 <Label Content="*" Foreground="Red" FontWeight="Bold" />
-                <TextBox Name="sequencesInducingCleavageTextBox" Width="155" Height="20">
+                <local:MotifTextBoxControl x:Name="sequencesInducingCleavageTextBox" Width="155" Height="20">
                     <ToolTipService.ToolTip>
-                        <ToolTip Content="Use single letter code and separate with ','"/>
+                        <ToolTip Content="Use single letter code and separate with comma"/>
                     </ToolTipService.ToolTip>
                     <TextBox.Style>
-                        <Style TargetType="TextBox" xmlns:sys="clr-namespace:System;assembly=mscorlib">
+                        <Style TargetType="local:MotifTextBoxControl" xmlns:sys="clr-namespace:System;assembly=mscorlib">
                             <Style.Resources>
                                 <VisualBrush x:Key="CueBannerBrush" AlignmentX="Left" AlignmentY="Center" Stretch="None">
                                     <VisualBrush.Visual>
-                                        <Label Content="ex: 'K,R'" Foreground="Gray" />
+                                        <Label Content= "K,R" Foreground="Gray" />
                                     </VisualBrush.Visual>
                                 </VisualBrush>
                             </Style.Resources>
@@ -70,22 +70,22 @@
                             </Style.Triggers>
                         </Style>
                     </TextBox.Style>
-                </TextBox>
+                </local:MotifTextBoxControl>
             </StackPanel>
             <!--What Stops it from Cleaving there-->
             <StackPanel Orientation="Horizontal">
                 <Label Content="Sequences Preventing Cleavage" Width="180" Style="{StaticResource xSmallHeaderLabelStyle}"></Label>
                 <Label Content="*" Foreground="Red" FontWeight="Bold" />
-                <TextBox Name="sequencesPreventingCleavageBox" Width="155" Height="20">
+                <local:MotifTextBoxControl x:Name="sequencesPreventingCleavageBox" Width="155" Height="20">
                     <ToolTipService.ToolTip>
-                        <ToolTip Content="Use single amino acid code and separate with ','"/>
+                        <ToolTip Content="Use single amino acid code and separate with comma"/>
                     </ToolTipService.ToolTip>
                     <TextBox.Style>
-                        <Style TargetType="TextBox" xmlns:sys="clr-namespace:System;assembly=mscorlib">
+                        <Style TargetType="local:MotifTextBoxControl" xmlns:sys="clr-namespace:System;assembly=mscorlib">
                             <Style.Resources>
                                 <VisualBrush x:Key="CueBannerBrush" AlignmentX="Left" AlignmentY="Center" Stretch="None">
                                     <VisualBrush.Visual>
-                                        <Label Content="ex: 'P'" Foreground="Gray" />
+                                        <Label Content="P" Foreground="Gray" />
                                     </VisualBrush.Visual>
                                 </VisualBrush>
                             </Style.Resources>
@@ -102,7 +102,7 @@
                             </Style.Triggers>
                         </Style>
                     </TextBox.Style>
-                </TextBox>
+                </local:MotifTextBoxControl>
             </StackPanel>            
             <!--Location Restriction-->
             <StackPanel Orientation="Horizontal">

--- a/GUI/CustomProteaseWindow.xaml.cs
+++ b/GUI/CustomProteaseWindow.xaml.cs
@@ -91,7 +91,8 @@ namespace GUI
 
             if (allResiduesStoppingCleavage != "")
             {
-                singlePreventionSites = allResiduesStoppingCleavage.Split(',').ToList();
+                //it is possible that someone will put two commas in a row, which would result in whitespace which is not acceptable
+                singlePreventionSites = allResiduesStoppingCleavage.Split(',').Where(s=>!s.ToString().IsNullOrEmptyOrWhiteSpace()).ToList();
             }
 
             if (cleavageTerminus == "C")

--- a/GUI/CustomProteaseWindow.xaml.cs
+++ b/GUI/CustomProteaseWindow.xaml.cs
@@ -1,27 +1,11 @@
 ﻿using Proteomics;
-using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using Engine;
-using Tasks;
 using Proteomics.ProteolyticDigestion;
 using System.IO;
-using System.Globalization;
 using static Tasks.ProteaseGuruTask;
-using MzLibUtil;
-using System.ComponentModel;
 using Easy.Common.Extensions;
 
 namespace GUI

--- a/GUI/CustomProteaseWindow.xaml.cs
+++ b/GUI/CustomProteaseWindow.xaml.cs
@@ -167,6 +167,5 @@ namespace GUI
             psiAccessionNumber.Clear();
             psiName.Clear();
         }
-
     }
 }

--- a/GUI/CustomProteaseWindow.xaml.cs
+++ b/GUI/CustomProteaseWindow.xaml.cs
@@ -22,6 +22,7 @@ using System.Globalization;
 using static Tasks.ProteaseGuruTask;
 using MzLibUtil;
 using System.ComponentModel;
+using Easy.Common.Extensions;
 
 namespace GUI
 {
@@ -84,7 +85,8 @@ namespace GUI
 
             if (allCleavageResidues != "")
             {
-                singleCleavageSites = allCleavageResidues.Split(',').ToList();
+                //it is possible that someone will put two commas in a row, which would result in whitespace which is not acceptable
+                singleCleavageSites = allCleavageResidues.Split(',').Where(s=>!s.IsNullOrEmptyOrWhiteSpace()).ToList();
             }
 
             if (allResiduesStoppingCleavage != "")

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="mzLib" Version="1.0.485" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -5,22 +5,14 @@
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Icons\proteaseGuru.ico</ApplicationIcon>
-    <Platforms>AnyCPU;x64</Platforms>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>   
     <None Remove="proteaseGuru.ico" /> 
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Icons\proteaseGuru.ico</ApplicationIcon>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>   
@@ -15,7 +16,15 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/GUI/MotifTextBoxControl.cs
+++ b/GUI/MotifTextBoxControl.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+using System.Windows.Input;
+
+namespace GUI
+{
+    public class MotifTextBoxControl : TextBox
+    {
+        protected override void OnPreviewTextInput(TextCompositionEventArgs e)
+        {
+
+            List<char> acceptableChars = new List<char>()
+            {
+                'A', 'R', 'N', 'D', 'C', 'E', 'Q', 'G', 'H', 'I', 'L', 'K', 'M', 'F', 'P', 'S', 'T', 'W', 'Y', 'V', ','
+            };
+
+            foreach (var character in e.Text)
+            {
+                if (acceptableChars.Contains(character))
+                {
+                    e.Handled = false;
+                    return;
+                }
+            }
+
+            e.Handled = true;
+        }
+    }
+}

--- a/ProteaseGuru.sln
+++ b/ProteaseGuru.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29728.190
+# Visual Studio Version 17
+VisualStudioVersion = 17.6.33712.159
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GUI", "GUI\GUI.csproj", "{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}"
 EndProject
@@ -9,30 +9,48 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tasks", "Tasks\Tasks.csproj
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Engine", "Engine\Engine.csproj", "{0401D402-DD1F-4492-9871-A3A514081471}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test", "Test\Test.csproj", "{D21C3C88-E27A-47D2-9A93-CE156B46F566}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test", "Test\Test.csproj", "{D21C3C88-E27A-47D2-9A93-CE156B46F566}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Debug|x64.ActiveCfg = Debug|x64
+		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Debug|x64.Build.0 = Debug|x64
 		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Release|x64.ActiveCfg = Release|x64
+		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Release|x64.Build.0 = Release|x64
 		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Debug|x64.ActiveCfg = Debug|x64
+		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Debug|x64.Build.0 = Debug|x64
 		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Release|x64.ActiveCfg = Release|x64
+		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Release|x64.Build.0 = Release|x64
 		{0401D402-DD1F-4492-9871-A3A514081471}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0401D402-DD1F-4492-9871-A3A514081471}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0401D402-DD1F-4492-9871-A3A514081471}.Debug|x64.ActiveCfg = Debug|x64
+		{0401D402-DD1F-4492-9871-A3A514081471}.Debug|x64.Build.0 = Debug|x64
 		{0401D402-DD1F-4492-9871-A3A514081471}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0401D402-DD1F-4492-9871-A3A514081471}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0401D402-DD1F-4492-9871-A3A514081471}.Release|x64.ActiveCfg = Release|x64
+		{0401D402-DD1F-4492-9871-A3A514081471}.Release|x64.Build.0 = Release|x64
 		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Debug|x64.ActiveCfg = Debug|x64
+		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Debug|x64.Build.0 = Debug|x64
 		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Release|x64.ActiveCfg = Release|x64
+		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ProteaseGuru.sln
+++ b/ProteaseGuru.sln
@@ -13,42 +13,24 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test", "Test\Test.csproj", 
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Debug|x64 = Debug|x64
-		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Debug|x64.ActiveCfg = Debug|x64
 		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Debug|x64.Build.0 = Debug|x64
-		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Release|x64.ActiveCfg = Release|x64
 		{2AB94619-9C3F-40A7-847A-F68CCBED5B1D}.Release|x64.Build.0 = Release|x64
-		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Debug|x64.ActiveCfg = Debug|x64
 		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Debug|x64.Build.0 = Debug|x64
-		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Release|Any CPU.Build.0 = Release|Any CPU
 		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Release|x64.ActiveCfg = Release|x64
 		{74915ADC-C898-4396-AC13-68F4EFB882DB}.Release|x64.Build.0 = Release|x64
-		{0401D402-DD1F-4492-9871-A3A514081471}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0401D402-DD1F-4492-9871-A3A514081471}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0401D402-DD1F-4492-9871-A3A514081471}.Debug|x64.ActiveCfg = Debug|x64
 		{0401D402-DD1F-4492-9871-A3A514081471}.Debug|x64.Build.0 = Debug|x64
-		{0401D402-DD1F-4492-9871-A3A514081471}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0401D402-DD1F-4492-9871-A3A514081471}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0401D402-DD1F-4492-9871-A3A514081471}.Release|x64.ActiveCfg = Release|x64
 		{0401D402-DD1F-4492-9871-A3A514081471}.Release|x64.Build.0 = Release|x64
-		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Debug|x64.ActiveCfg = Debug|x64
 		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Debug|x64.Build.0 = Debug|x64
-		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Release|x64.ActiveCfg = Release|x64
 		{D21C3C88-E27A-47D2-9A93-CE156B46F566}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection

--- a/Tasks/Tasks.csproj
+++ b/Tasks/Tasks.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="mzLib" Version="1.0.485" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>
 

--- a/Tasks/Tasks.csproj
+++ b/Tasks/Tasks.csproj
@@ -5,18 +5,10 @@
     <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
-    <Platforms>AnyCPU;x64</Platforms>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/Tasks/Tasks.csproj
+++ b/Tasks/Tasks.csproj
@@ -2,16 +2,25 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject />
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="mzLib" Version="1.0.485" />
+    <PackageReference Include="mzLib" Version="1.0.541" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
   </ItemGroup>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -3,18 +3,10 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <Platforms>AnyCPU;x64</Platforms>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <PlatformTarget>x64</PlatformTarget>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -2,14 +2,23 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
+    <Platforms>AnyCPU;x64</Platforms>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.102",
+    "version": "6.0.402",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
User requested addition of these two proteases. Cleavage motifs were found in these two resources

Pepsin: c-terminal of F, L, Y and W
https://www.promega.com/products/mass-spectrometry/proteases-and-surfactants/pepsin/?catNum=V1959

Papain: c-terminal of L and G
https://www.sigmaaldrich.com/US/en/product/sigma/p3125
