### PR TITLE
Update some ancient things and mzlib

### DIFF
--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="mzLib" Version="1.0.564" />
+    <PackageReference Include="mzLib" Version="1.0.572" />
     <PackageReference Include="TopDownProteomics" Version="0.0.287" />
   </ItemGroup>
 

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="mzLib" Version="1.0.564" />
+    <PackageReference Include="mzLib" Version="1.0.572" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="OxyPlot.Core" Version="2.0.0" />
     <PackageReference Include="OxyPlot.Wpf" Version="2.0.0" />

--- a/Tasks/Tasks.csproj
+++ b/Tasks/Tasks.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="mzLib" Version="1.0.564" />
+    <PackageReference Include="mzLib" Version="1.0.572" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>
 

--- a/Test/DigestionTests.cs
+++ b/Test/DigestionTests.cs
@@ -11,7 +11,7 @@ using UsefulProteomicsDatabases;
 namespace Test
 {
     [TestFixture]
-    public static class DigestionTests
+    public class DigestionTests
     {
 
         //[OneTimeSetUp]

--- a/Test/DigestionTests.cs
+++ b/Test/DigestionTests.cs
@@ -11,7 +11,7 @@ using UsefulProteomicsDatabases;
 namespace Test
 {
     [TestFixture]
-    internal static class DigestionTests
+    public static class DigestionTests
     {
 
         //[OneTimeSetUp]

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 <ItemGroup>
   <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-  <PackageReference Include="mzLib" Version="1.0.564" />
+  <PackageReference Include="mzLib" Version="1.0.572" />
   <PackageReference Include="NUnit" Version="3.14.0" />
   <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 </ItemGroup>

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -14,12 +14,12 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="mzLib" Version="1.0.564" />
-    <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-  </ItemGroup>
+<ItemGroup>
+  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+  <PackageReference Include="mzLib" Version="1.0.564" />
+  <PackageReference Include="NUnit" Version="3.14.0" />
+  <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+</ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\Engine\Engine.csproj" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.204",
+    "version": "8.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "8.0.204",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
This pull request mainly updates package dependencies across several projects, with a few minor configuration changes. The most significant updates are to the `mzLib` package version, and there are also updates to test dependencies and project SDK settings.

**Dependency Updates:**

* Upgraded the `mzLib` package from version `1.0.564` to `1.0.572` in `Engine.csproj`, `GUI.csproj`, `Tasks.csproj`, and `Test.csproj` to ensure all projects use the latest features and bug fixes. [[1]](diffhunk://#diff-f8c09aff2ccc658b9d0f98d481402b987b6963b8f0be834f9d524b0e4cb7f1c6L20-R20) [[2]](diffhunk://#diff-b71fc64e51682f0b2423cfacd8b9aeb58c21c836dd469ecf5b1cc3c5a233d1ccL24-R24) [[3]](diffhunk://#diff-626776ad8d95a496d665b3a6ee98d3bc58cccab972a922af24a05194f3e30434L20-R20) [[4]](diffhunk://#diff-6b9b9b4014ccddab8742d8a21f7e7aaab4319ee3eee5a6ab04fde717c522e547L18-R21)
* Updated test-related packages in `Test.csproj`: `Microsoft.NET.Test.Sdk` to `17.8.0`, `NUnit` to `3.14.0`, and `NUnit3TestAdapter` to `4.5.0` for improved testing capabilities and compatibility.

**Project Configuration Changes:**

* Changed the SDK in `GUI.csproj` from `Microsoft.NET.Sdk.WindowsDesktop` to `Microsoft.NET.Sdk`, which may affect desktop-specific features and deployment.
* Updated the .NET SDK version in `global.json` from `8.0.204` to `8.0.100`, which sets the version used for builds and development.

**Code Accessibility:**

* Changed the `DigestionTests` class in `Test/DigestionTests.cs` from `internal` to `public`, allowing it to be accessed from other assemblies if needed.