### PR TITLE
Parallelization of Retention Time Calculations and Clean-up of Protein Window

### DIFF
--- a/GUI/ProteinDigestionSummaryRow.cs
+++ b/GUI/ProteinDigestionSummaryRow.cs
@@ -6,11 +6,11 @@ namespace GUI
     /// </summary>
     public class ProteinDigestionSummaryRow
     {
-        public string Protease { get; set; }
+        public string Protease { get; set; } = string.Empty;
         public int UniquePeptides { get; set; }
         public int SharedPeptides { get; set; }
         public int TotalPeptides => UniquePeptides + SharedPeptides;
-        public string TotalCoverage { get; set; }
-        public string UniqueCoverage { get; set; }
+        public string TotalCoverage { get; set; } = string.Empty;
+        public string UniqueCoverage { get; set; } = string.Empty;
     }
 }

--- a/GUI/ProteinDigestionSummaryRow.cs
+++ b/GUI/ProteinDigestionSummaryRow.cs
@@ -1,0 +1,16 @@
+namespace GUI
+{
+    /// <summary>
+    /// Represents a single row in the protein digestion summary table.
+    /// Each row contains digestion results for one protease.
+    /// </summary>
+    public class ProteinDigestionSummaryRow
+    {
+        public string Protease { get; set; }
+        public int UniquePeptides { get; set; }
+        public int SharedPeptides { get; set; }
+        public int TotalPeptides => UniquePeptides + SharedPeptides;
+        public string TotalCoverage { get; set; }
+        public string UniqueCoverage { get; set; }
+    }
+}

--- a/GUI/ProteinResultsWindow.xaml
+++ b/GUI/ProteinResultsWindow.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="GUI.ProteinResultsWindow"
+<UserControl x:Class="GUI.ProteinResultsWindow"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -129,15 +129,15 @@
 
                 <Grid Grid.Row="2" Style="{StaticResource InternalGridStyle}">
                     <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*"/>                        
+                        <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
                     <Grid.RowDefinitions>
                         <RowDefinition Height=".9*"/>
                     </Grid.RowDefinitions>
-                  
-                    <ListBox Name ="dataGridProteins" SelectionMode="Single" ItemContainerStyle="{StaticResource ListBoxItem}" SelectionChanged="proteins_SelectedCellsChanged"> </ListBox>
-                    
-                </Grid>                
+
+                    <ListBox Name ="dataGridProteins" SelectionMode="Single" ItemContainerStyle="{StaticResource ListBoxItem}" SelectionChanged="proteins_SelectedCellsChanged"></ListBox>
+
+                </Grid>
             </Grid>
 
             <GridSplitter Grid.Column="1" 
@@ -175,43 +175,81 @@
                 </Grid.RowDefinitions>
                 <Grid Grid.Row="0" Name="SummaryGrid" Style="{StaticResource InternalGridStyle}">
                     <Grid.RowDefinitions>
-                        <RowDefinition Height=" 35"></RowDefinition>
+                        <RowDefinition Height="35"></RowDefinition>
                         <RowDefinition Height="*"></RowDefinition>
                     </Grid.RowDefinitions>
                     <!--Header label-->
                     <Label Content="Protein Digestion Summary" Grid.Row="0" Style="{StaticResource SmallHeaderLabelStyle}" />
-                    <TreeView Grid.Row="1" x:Name="proteinResults" Width ="735" ItemsSource="{Binding}" DataContext="{x:Type gui:ProteinSummaryForTreeView}" ScrollViewer.VerticalScrollBarVisibility="Auto">
 
-                        <TreeView.Resources>
-                            <HierarchicalDataTemplate DataType="{x:Type gui:ProteinSummaryForTreeView}" ItemsSource="{Binding Summary}">
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock Text="{Binding DisplayName}" FontSize="16" />
-                                </StackPanel>
-                            </HierarchicalDataTemplate>
-                            <HierarchicalDataTemplate DataType="{x:Type gui:AnalysisSummaryForTreeView}" ItemsSource="{Binding Summary}">
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock Text="{Binding DisplayName}" FontSize="15"/>
-                                </StackPanel>
-                            </HierarchicalDataTemplate>
-                            <DataTemplate DataType="{x:Type gui:ProtSummaryForTreeView}">
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock Text="{Binding DisplayName}" FontSize="13.5"/>
-                                </StackPanel>
-                            </DataTemplate>
-                        </TreeView.Resources>
-                        <TreeView.ItemContainerStyle>
-                            <Style TargetType="TreeViewItem">
-                                <Style.Resources>
-                                    <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="#fdd8c1"/>
-                                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="#fdd8c1"/>
-                                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="#131313"/>
-                                    <SolidColorBrush x:Key="{x:Static SystemColors.InactiveSelectionHighlightBrushKey}" Color="#fdd8c1"/>
-                                </Style.Resources>
-                                <Setter Property="IsExpanded" Value="{Binding Expanded}"/>
-                            </Style>
-                        </TreeView.ItemContainerStyle>
-                    </TreeView>
-                    
+                    <!-- FIXED: Added Grid.Row="1" to place content below the header -->
+                    <StackPanel Grid.Row="1">
+                        <Label x:Name="proteinSummaryHeader" 
+                               FontWeight="Bold" 
+                               FontSize="14" 
+                               Margin="5,5,5,0"/>
+
+                        <DataGrid x:Name="proteinSummaryGrid"
+                                  AutoGenerateColumns="False"
+                                  IsReadOnly="True"
+                                  CanUserAddRows="False"
+                                  CanUserDeleteRows="False"
+                                  HeadersVisibility="Column"
+                                  GridLinesVisibility="All"
+                                  AlternatingRowBackground="#F5F5F5"
+                                  Margin="5">
+                            <DataGrid.Columns>
+                                <DataGridTextColumn Header="Protease" 
+                                                    Binding="{Binding Protease}" 
+                                                    Width="Auto" 
+                                                    MinWidth="150"/>
+                                <DataGridTextColumn Header="Unique Peptides" 
+                                                    Binding="{Binding UniquePeptides}" 
+                                                    Width="Auto">
+                                    <DataGridTextColumn.ElementStyle>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="HorizontalAlignment" Value="Center"/>
+                                        </Style>
+                                    </DataGridTextColumn.ElementStyle>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Header="Shared Peptides" 
+                                                    Binding="{Binding SharedPeptides}" 
+                                                    Width="Auto">
+                                    <DataGridTextColumn.ElementStyle>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="HorizontalAlignment" Value="Center"/>
+                                        </Style>
+                                    </DataGridTextColumn.ElementStyle>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Header="Total Peptides" 
+                                                    Binding="{Binding TotalPeptides}" 
+                                                    Width="Auto">
+                                    <DataGridTextColumn.ElementStyle>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="HorizontalAlignment" Value="Center"/>
+                                        </Style>
+                                    </DataGridTextColumn.ElementStyle>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Header="Total Coverage" 
+                                                    Binding="{Binding TotalCoverage}" 
+                                                    Width="Auto">
+                                    <DataGridTextColumn.ElementStyle>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="HorizontalAlignment" Value="Center"/>
+                                        </Style>
+                                    </DataGridTextColumn.ElementStyle>
+                                </DataGridTextColumn>
+                                <DataGridTextColumn Header="Unique Coverage" 
+                                                    Binding="{Binding UniqueCoverage}" 
+                                                    Width="Auto">
+                                    <DataGridTextColumn.ElementStyle>
+                                        <Style TargetType="TextBlock">
+                                            <Setter Property="HorizontalAlignment" Value="Center"/>
+                                        </Style>
+                                    </DataGridTextColumn.ElementStyle>
+                                </DataGridTextColumn>
+                            </DataGrid.Columns>
+                        </DataGrid>
+                    </StackPanel>
                 </Grid>
                 <Grid Grid.Row="1" Name="ResultsGrid" SizeChanged="resultsSizeChanged" Style="{StaticResource InternalGridStyle}">
                     <Grid.RowDefinitions>
@@ -242,7 +280,7 @@
 
                 </Grid>
             </Grid>
-            
+
         </Grid>
     </Grid>
 </UserControl>

--- a/GUI/ProteinResultsWindow.xaml.cs
+++ b/GUI/ProteinResultsWindow.xaml.cs
@@ -409,17 +409,11 @@ namespace GUI
                 {
                     totalCoverage = $"{Math.Round(coverageValues.Item1, 2)}%";
 
-                    if (_analyzer.IsMultiDatabase)
-                    {
-                        // Look up pre-computed unique coverage
-                        uniqueCoverage = uniqueCoverageByProtease!.TryGetValue(proteaseName, out var fraction)
+                    uniqueCoverage = _analyzer.IsMultiDatabase
+                        ? uniqueCoverageByProtease!.TryGetValue(proteaseName, out var fraction)
                             ? $"{Math.Round(fraction * 100, 2)}%"
-                            : "N/A";
-                    }
-                    else
-                    {
-                        uniqueCoverage = $"{Math.Round(coverageValues.Item2, 2)}%";
-                    }
+                            : "N/A"
+                        : $"{Math.Round(coverageValues.Item2, 2)}%";
                 }
 
                 summaryRows.Add(new ProteinDigestionSummaryRow

--- a/GUI/ProteinResultsWindow.xaml.cs
+++ b/GUI/ProteinResultsWindow.xaml.cs
@@ -40,11 +40,6 @@ namespace GUI
         private ObservableCollection<string> filteredList;
 
         /// <summary>
-        /// Tree view data for displaying protein digestion summary statistics
-        /// </summary>
-        private ObservableCollection<ProteinSummaryForTreeView> ProteinDigestionSummary;
-
-        /// <summary>
         /// Maps Protein objects to their tree view representation (GUI-specific)
         /// </summary>
         private Dictionary<Protein, ProteinForTreeView> ProteinsForTreeView;
@@ -124,7 +119,6 @@ namespace GUI
             MessageShow = true;
 
             // Initialize GUI collections
-            ProteinDigestionSummary = new ObservableCollection<ProteinSummaryForTreeView>();
             proteinList = new ObservableCollection<string>();
             filteredList = new ObservableCollection<string>();
             ProteinsForTreeView = new Dictionary<Protein, ProteinForTreeView>();
@@ -376,7 +370,7 @@ namespace GUI
         }
 
         /// <summary>
-        /// Builds the protein summary tree view using analyzer data
+        /// Builds the protein summary table using analyzer data
         /// </summary>
         private void BuildProteinSummary()
         {
@@ -386,59 +380,53 @@ namespace GUI
             var uniquePepCounts = coverageResult.GetUniquePeptideCountsByProtease();
             var sharedPepCounts = coverageResult.GetSharedPeptideCountsByProtease();
 
-            // Create tree view structure
-            var thisProtein = new ProteinSummaryForTreeView($"Digestion Results for {coverageResult.DisplayName}:");
+            // Update the header label
+            proteinSummaryHeader.Content = $"Digestion Results for {coverageResult.DisplayName}";
 
-            // Unique peptide counts
-            var uniquePep = new AnalysisSummaryForTreeView("Number of Unique Peptides: ");
-            foreach (var protease in proteaseList)
-            {
-                int count = uniquePepCounts.TryGetValue(protease, out var c) ? c : 0;
-                uniquePep.Summary.Add(new ProtSummaryForTreeView($"{protease}: {count}"));
-            }
-            thisProtein.Summary.Add(uniquePep);
+            // Build table rows
+            var summaryRows = new List<ProteinDigestionSummaryRow>();
 
-            // Shared peptide counts
-            var sharedPep = new AnalysisSummaryForTreeView("Number of Shared Peptides: ");
-            foreach (var protease in proteaseList)
+            foreach (var proteaseName in proteaseList)
             {
-                int count = sharedPepCounts.TryGetValue(protease, out var c) ? c : 0;
-                sharedPep.Summary.Add(new ProtSummaryForTreeView($"{protease}: {count}"));
-            }
-            thisProtein.Summary.Add(sharedPep);
+                int uniqueCount = uniquePepCounts.TryGetValue(proteaseName, out var uc) ? uc : 0;
+                int sharedCount = sharedPepCounts.TryGetValue(proteaseName, out var sc) ? sc : 0;
 
-            // Total sequence coverage
-            var percentCov = new AnalysisSummaryForTreeView("Percent Sequence Coverage (all peptides):");
-            foreach (var protease in _analyzer.SequenceCoverageByProtease)
-            {
-                var coverage = Math.Round(protease.Value[SelectedProtein.Protein].Item1, 2);
-                percentCov.Summary.Add(new ProtSummaryForTreeView($"{protease.Key}: {Math.Round(coverage, 3)}%"));
-            }
-            thisProtein.Summary.Add(percentCov);
+                // Get coverage values
+                string totalCoverage = "N/A";
+                string uniqueCoverage = "N/A";
 
-            // Unique peptide coverage
-            var percentCovUniq = new AnalysisSummaryForTreeView("Percent Sequence Coverage (unique peptides):");
-            if (_analyzer.IsMultiDatabase)
-            {
-                foreach (var (proteaseName, fraction) in _analyzer.CalculateSequenceCoverageUnique(SelectedProtein.Protein))
+                if (_analyzer.SequenceCoverageByProtease.TryGetValue(proteaseName, out var proteaseCoverage) &&
+                    proteaseCoverage.TryGetValue(SelectedProtein.Protein, out var coverageValues))
                 {
-                    percentCovUniq.Summary.Add(new ProtSummaryForTreeView($"{proteaseName}: {Math.Round(fraction, 3)}%"));
-                }
-            }
-            else
-            {
-                foreach (var protease in _analyzer.SequenceCoverageByProtease)
-                {
-                    var coverage = protease.Value[SelectedProtein.Protein].Item2;
-                    percentCovUniq.Summary.Add(new ProtSummaryForTreeView($"{protease.Key}: {Math.Round(coverage, 3)}%"));
-                }
-            }
-            thisProtein.Summary.Add(percentCovUniq);
+                    totalCoverage = $"{Math.Round(coverageValues.Item1, 2)}%";
 
-            // Update display
-            ProteinDigestionSummary.Clear();
-            ProteinDigestionSummary.Add(thisProtein);
-            proteinResults.DataContext = ProteinDigestionSummary;
+                    if (_analyzer.IsMultiDatabase)
+                    {
+                        // For multi-database, calculate unique coverage differently
+                        var uniqueCoverageCalc = _analyzer.CalculateSequenceCoverageUnique(SelectedProtein.Protein)
+                            .FirstOrDefault(x => x.ProteaseName == proteaseName);
+                        uniqueCoverage = uniqueCoverageCalc.ProteaseName != null
+                            ? $"{Math.Round(uniqueCoverageCalc.CoverageFraction * 100, 2)}%"
+                            : "N/A";
+                    }
+                    else
+                    {
+                        uniqueCoverage = $"{Math.Round(coverageValues.Item2, 2)}%";
+                    }
+                }
+
+                summaryRows.Add(new ProteinDigestionSummaryRow
+                {
+                    Protease = proteaseName,
+                    UniquePeptides = uniqueCount,
+                    SharedPeptides = sharedCount,
+                    TotalCoverage = totalCoverage,
+                    UniqueCoverage = uniqueCoverage
+                });
+            }
+
+            // Bind to the DataGrid
+            proteinSummaryGrid.ItemsSource = summaryRows;
         }
 
         #endregion
@@ -813,17 +801,19 @@ namespace GUI
 
             // Save results summary
             var resultsFile = $"{proteinName}_DigestionResults.txt";
-            var results = new List<string>();
-            foreach (var protein in ProteinDigestionSummary)
+            var results = new List<string>
             {
-                results.Add(protein.DisplayName);
-                foreach (var analysis in protein.Summary)
+                $"Digestion Results for {proteinName}",
+                "",
+                "Protease\tUnique Peptides\tShared Peptides\tTotal Peptides\tTotal Coverage\tUnique Coverage"
+            };
+
+            // Get data from the summary grid
+            if (proteinSummaryGrid.ItemsSource is List<ProteinDigestionSummaryRow> summaryRows)
+            {
+                foreach (var row in summaryRows)
                 {
-                    results.Add($"   {analysis.DisplayName}");
-                    foreach (var protease in analysis.Summary)
-                    {
-                        results.Add($"       {protease.DisplayName}");
-                    }
+                    results.Add($"{row.Protease}\t{row.UniquePeptides}\t{row.SharedPeptides}\t{row.TotalPeptides}\t{row.TotalCoverage}\t{row.UniqueCoverage}");
                 }
             }
             File.WriteAllLines(Path.Combine(subFolder, resultsFile), results);

--- a/GUI/ProteinResultsWindow.xaml.cs
+++ b/GUI/ProteinResultsWindow.xaml.cs
@@ -383,6 +383,15 @@ namespace GUI
             // Update the header label
             proteinSummaryHeader.Content = $"Digestion Results for {coverageResult.DisplayName}";
 
+            // Pre-compute unique coverage for multi-database scenario (once, not per-protease)
+            Dictionary<string, double>? uniqueCoverageByProtease = null;
+            if (_analyzer.IsMultiDatabase)
+            {
+                uniqueCoverageByProtease = _analyzer
+                    .CalculateSequenceCoverageUnique(SelectedProtein.Protein)
+                    .ToDictionary(x => x.ProteaseName, x => x.CoverageFraction);
+            }
+
             // Build table rows
             var summaryRows = new List<ProteinDigestionSummaryRow>();
 
@@ -402,11 +411,9 @@ namespace GUI
 
                     if (_analyzer.IsMultiDatabase)
                     {
-                        // For multi-database, calculate unique coverage differently
-                        var uniqueCoverageCalc = _analyzer.CalculateSequenceCoverageUnique(SelectedProtein.Protein)
-                            .FirstOrDefault(x => x.ProteaseName == proteaseName);
-                        uniqueCoverage = uniqueCoverageCalc.ProteaseName != null
-                            ? $"{Math.Round(uniqueCoverageCalc.CoverageFraction * 100, 2)}%"
+                        // Look up pre-computed unique coverage
+                        uniqueCoverage = uniqueCoverageByProtease!.TryGetValue(proteaseName, out var fraction)
+                            ? $"{Math.Round(fraction * 100, 2)}%"
                             : "N/A";
                     }
                     else

--- a/GUI/ProteinResultsWindow.xaml.cs
+++ b/GUI/ProteinResultsWindow.xaml.cs
@@ -809,13 +809,10 @@ namespace GUI
                 "Protease\tUnique Peptides\tShared Peptides\tTotal Peptides\tTotal Coverage\tUnique Coverage"
             };
 
-            // Get data from the summary grid
-            if (proteinSummaryGrid.ItemsSource is List<ProteinDigestionSummaryRow> summaryRows)
+            // Get data from the summary grid - use Items.OfType for robustness
+            foreach (var row in proteinSummaryGrid.Items.OfType<ProteinDigestionSummaryRow>())
             {
-                foreach (var row in summaryRows)
-                {
-                    results.Add($"{row.Protease}\t{row.UniquePeptides}\t{row.SharedPeptides}\t{row.TotalPeptides}\t{row.TotalCoverage}\t{row.UniqueCoverage}");
-                }
+                results.Add($"{row.Protease}\t{row.UniquePeptides}\t{row.SharedPeptides}\t{row.TotalPeptides}\t{row.TotalCoverage}\t{row.UniqueCoverage}");
             }
             File.WriteAllLines(Path.Combine(subFolder, resultsFile), results);
 

--- a/Tasks/CoverageMapConfiguration/ProteinCoverageAnalyzer.cs
+++ b/Tasks/CoverageMapConfiguration/ProteinCoverageAnalyzer.cs
@@ -167,7 +167,7 @@ namespace Tasks.CoverageMapConfiguration
         /// Calculates sequence coverage using only unique peptides for a specific protein
         /// </summary>
         /// <param name="protein">The protein to calculate coverage for</param>
-        /// <returns>Enumerable of (protease name, coverage fraction) tuples</returns>
+        /// <returns>Enumerable of (protease name, coverage fraction) tuples where fraction is 0.0-1.0 (unrounded)</returns>
         public IEnumerable<(string ProteaseName, double CoverageFraction)> CalculateSequenceCoverageUnique(Protein protein)
         {
             if (!PeptideByProteaseAndProtein.ContainsKey(protein))
@@ -193,9 +193,9 @@ namespace Tasks.CoverageMapConfiguration
                     }
                 }
 
-                // Calculate coverage fraction
+                // Return unrounded fraction - let caller handle display formatting
                 var fraction = (double)coveredOneBasedResidues.Count / protein.Length;
-                yield return (proteaseKvp.Key, Math.Round(fraction, 2));
+                yield return (proteaseKvp.Key, fraction);
             }
         }
 

--- a/Tasks/DigestionTask.cs
+++ b/Tasks/DigestionTask.cs
@@ -15,6 +15,10 @@ namespace Tasks
     {
         // Maximum concurrency for parallel operations
         private static readonly int MaxConcurrency = Environment.ProcessorCount;
+        
+        // Calculated parallelism limits to avoid oversubscription
+        private static readonly int OuterParallelism = Math.Max(1, MaxConcurrency / 2);
+        private static readonly int InnerParallelism = Math.Max(1, MaxConcurrency / OuterParallelism);
 
         public DigestionTask(): base(MyTask.Digestion)
         { 
@@ -38,10 +42,11 @@ namespace Tasks
             // Use a thread-safe dictionary for parallel writes
             var concurrentPeptideByFile = new ConcurrentDictionary<string, ConcurrentDictionary<string, Dictionary<Protein, List<InSilicoPep>>>>();
 
-            // Limit outer parallelism to avoid oversubscription with inner parallel loops
+            // Outer parallelism: limited to avoid oversubscription with inner parallel loops
+            // With 8 cores: OuterParallelism = 4, InnerParallelism = 2, total max = 4 * 2 = 8 threads
             var outerParallelOptions = new ParallelOptions 
             { 
-                MaxDegreeOfParallelism = Math.Max(1, MaxConcurrency / 2) 
+                MaxDegreeOfParallelism = OuterParallelism 
             };
 
             // Process each database in parallel (limited)
@@ -323,7 +328,8 @@ namespace Tasks
 
             if (peptides.Count == 0) return results;
 
-            int threadCount = Math.Min(Environment.ProcessorCount, peptides.Count);
+            // Use inner parallelism, but also limited by pool size and peptide count
+            int threadCount = Math.Min(InnerParallelism, Math.Min(_poolSize, peptides.Count));
             if (threadCount < 1) threadCount = 1;
 
             // Ensure pool has enough predictors
@@ -363,9 +369,10 @@ namespace Tasks
             var results = new double[peptides.Count];
             if (peptides.Count == 0) return results;
 
+            // Use inner parallelism to avoid oversubscription when called from outer parallel loop
             var options = new ParallelOptions 
             { 
-                MaxDegreeOfParallelism = MaxConcurrency 
+                MaxDegreeOfParallelism = InnerParallelism 
             };
 
             Parallel.For(0, peptides.Count,
@@ -395,7 +402,7 @@ namespace Tasks
 
             var options = new ParallelOptions 
             { 
-                MaxDegreeOfParallelism = MaxConcurrency 
+                MaxDegreeOfParallelism = InnerParallelism 
             };
 
             Parallel.For(0, peptides.Count, options, i =>

--- a/Tasks/DigestionTask.cs
+++ b/Tasks/DigestionTask.cs
@@ -77,7 +77,7 @@ namespace Tasks
             Status("Writing Results Summary...", "summary");
 
             return myRunResults;
-        }
+        } 
         // Load proteins from XML or FASTA databases and keep them associated with the database file name from which they came from
         protected List<Protein> LoadProteins(DbForDigestion database)
         {                        

--- a/Tasks/DigestionTask.cs
+++ b/Tasks/DigestionTask.cs
@@ -736,7 +736,7 @@ namespace Tasks
             
             var numberOfPeptides = allPeptides.Count();
             const int peptidesPerFile = 1000000;
-            double numberOfFiles = (int)Math.Ceiling(numberOfPeptides / (double)peptidesPerFile);
+            int numberOfFiles = (int)Math.Ceiling(numberOfPeptides / (double)peptidesPerFile);
             var peptideIndex = 0;
 
             for (int fileCount = 1; fileCount <= numberOfFiles; fileCount++)
@@ -746,12 +746,12 @@ namespace Tasks
                 {
                     output.WriteLine(header);
 
-                    int peptdesWrittenToThisFile = 0;
-                    while (peptdesWrittenToThisFile < peptidesPerFile && peptideIndex < numberOfPeptides)
+                    int peptidesWrittenToThisFile = 0;
+                    while (peptidesWrittenToThisFile < peptidesPerFile && peptideIndex < numberOfPeptides)
                     {
                         output.WriteLine(allPeptides[peptideIndex].ToString());
                         peptideIndex++;
-                        peptdesWrittenToThisFile++;
+                        peptidesWrittenToThisFile++;
                     }
                 }
             }

--- a/Tasks/DigestionTask.cs
+++ b/Tasks/DigestionTask.cs
@@ -294,7 +294,21 @@ namespace Tasks
             }
         }
 
-        // Then update the BatchCalculateRetentionTimesChronologer method:
+        /// <summary>
+        /// Batch calculates Chronologer-predicted retention times for a collection of peptides.
+        /// Uses a shared, thread-safe predictor pool to avoid file access conflicts when loading
+        /// the Chronologer model. Predictions are parallelized across available processor cores.
+        /// </summary>
+        /// <param name="peptides">Collection of peptides to process</param>
+        /// <returns>
+        /// Array of predicted retention time values in the same order as input peptides.
+        /// Returns -1 for peptides where prediction fails.
+        /// </returns>
+        /// <remarks>
+        /// The predictor pool is reference-counted and shared across calls to avoid repeatedly
+        /// loading the Chronologer model file. Each worker thread is assigned a unique predictor
+        /// via atomic counter to ensure thread safety without locking during predictions.
+        /// </remarks>
         private double[] BatchCalculateRetentionTimesChronologer(List<PeptideWithSetModifications> peptides)
         {
             var results = new double[peptides.Count];

--- a/Tasks/DigestionTask.cs
+++ b/Tasks/DigestionTask.cs
@@ -15,7 +15,7 @@ namespace Tasks
     {
         // Shared concurrency limiter for all parallel operations in this task
         private static readonly int MaxConcurrency = Environment.ProcessorCount;
-        private SemaphoreSlim _concurrencyLimiter;
+        private SemaphoreSlim? _concurrencyLimiter;
 
         public DigestionTask(): base(MyTask.Digestion)
         { 

--- a/Tasks/DigestionTask.cs
+++ b/Tasks/DigestionTask.cs
@@ -10,186 +10,211 @@ using UsefulProteomicsDatabases;
 
 namespace Tasks
 {
-    //digest the provided databases with the proteases and parameters provided by the user
-    public class DigestionTask : ProteaseGuruTask
+    /// <summary>
+    /// Digests the provided databases with the proteases and parameters provided by the user.
+    /// Implements IDisposable to properly clean up Chronologer predictor resources.
+    /// </summary>
+    public class DigestionTask : ProteaseGuruTask, IDisposable
     {
+        #region Parallelism Configuration
+
         // Maximum concurrency for parallel operations
         private static readonly int MaxConcurrency = Environment.ProcessorCount;
-        
+
         // Calculated parallelism limits to avoid oversubscription
+        // With 8 cores: OuterParallelism = 4, InnerParallelism = 2, total max = 4 * 2 = 8 threads
         private static readonly int OuterParallelism = Math.Max(1, MaxConcurrency / 2);
         private static readonly int InnerParallelism = Math.Max(1, MaxConcurrency / OuterParallelism);
 
-        public DigestionTask(): base(MyTask.Digestion)
-        { 
-          DigestionParameters = new Parameters();
-        }
-        public static event EventHandler<StringEventArgs> DigestionWarnHandler;
+        #endregion
+
+        #region Chronologer Predictor Pool
+
+        // Instance-scoped predictor pool to avoid cross-instance race conditions
+        private readonly object _predictorLock = new object();
+        private ConcurrentBag<ChronologerRetentionTimePredictor>? _predictorPool;
+        private bool _disposed;
+
+        #endregion
+
+        #region Public Properties and Events
+
+        public static event EventHandler<StringEventArgs>? DigestionWarnHandler;
+        public static event EventHandler<StringEventArgs>? OutLabelStatusHandler;
+
         public Parameters DigestionParameters { get; set; }
-
         public Dictionary<string, Dictionary<string, Dictionary<Protein, List<InSilicoPep>>>>? PeptideByFile;
-
-        public static event EventHandler<StringEventArgs> OutLabelStatusHandler;
-
         public static Dictionary<string, Dictionary<Protein, List<InSilicoPep>>>? AllPeptidesByProtease;
+        public Dictionary<string, Dictionary<Protein, (double, double)>> SequenceCoverageByProtease = new();
 
-        public  Dictionary<string, Dictionary<Protein, (double, double)>> SequenceCoverageByProtease = new Dictionary<string, Dictionary<Protein, (double, double)>>();
+        #endregion
+
+        #region Constructor
+
+        public DigestionTask() : base(MyTask.Digestion)
+        {
+            DigestionParameters = new Parameters();
+        }
+
+        #endregion
+
+        #region Main Execution
+
         public override MyTaskResults RunSpecific(string OutputFolder, List<DbForDigestion> dbFileList)
         {
-            AllPeptidesByProtease = new Dictionary<string, Dictionary<Protein, List<InSilicoPep>>>();
-            PeptideByFile = new Dictionary<string, Dictionary<string, Dictionary<Protein, List<InSilicoPep>>>>(dbFileList.Count);
+            // Initialize predictor pool for this run
+            InitializePredictorPool();
 
-            // Use a thread-safe dictionary for parallel writes
-            var concurrentPeptideByFile = new ConcurrentDictionary<string, ConcurrentDictionary<string, Dictionary<Protein, List<InSilicoPep>>>>();
-
-            // Outer parallelism: limited to avoid oversubscription with inner parallel loops
-            // With 8 cores: OuterParallelism = 4, InnerParallelism = 2, total max = 4 * 2 = 8 threads
-            var outerParallelOptions = new ParallelOptions 
-            { 
-                MaxDegreeOfParallelism = OuterParallelism 
-            };
-
-            // Process each database in parallel (limited)
-            Parallel.ForEach(dbFileList, outerParallelOptions, database =>
+            try
             {
-                Status("Loading Protein Database(s)...", "loadDbs");
-                List<Protein> proteins = LoadProteins(database);
+                AllPeptidesByProtease = new Dictionary<string, Dictionary<Protein, List<InSilicoPep>>>();
+                PeptideByFile = new Dictionary<string, Dictionary<string, Dictionary<Protein, List<InSilicoPep>>>>(dbFileList.Count);
 
-                // Initialize the entry for this database
-                var proteaseResults = new ConcurrentDictionary<string, Dictionary<Protein, List<InSilicoPep>>>();
-                concurrentPeptideByFile[database.FileName] = proteaseResults;
+                // Use a thread-safe dictionary for parallel writes
+                var concurrentPeptideByFile = new ConcurrentDictionary<string, ConcurrentDictionary<string, Dictionary<Protein, List<InSilicoPep>>>>();
 
-                // Capture variables for the inner parallel loop to avoid closure issues
-                string databaseFileName = database.FileName;
-                List<Protein> proteinsForDigestion = proteins;
-
-                // Process each protease sequentially within each database
-                // (inner batch methods handle parallelism)
-                foreach (var protease in DigestionParameters.ProteasesForDigestion)
+                // Outer parallelism: limited to avoid oversubscription with inner parallel loops
+                var outerParallelOptions = new ParallelOptions
                 {
-                    Status("Digesting Proteins...", "digestDbs");
+                    MaxDegreeOfParallelism = OuterParallelism
+                };
 
-                    var peptides = DigestDatabase(proteinsForDigestion, protease, DigestionParameters);
-                    var peptidesFormatted = DeterminePeptideStatus(databaseFileName, peptides, DigestionParameters);
+                // Process each database in parallel (limited)
+                Parallel.ForEach(dbFileList, outerParallelOptions, database =>
+                {
+                    Status("Loading Protein Database(s)...", "loadDbs");
+                    List<Protein> proteins = LoadProteins(database);
 
-                    proteaseResults[protease.Name] = peptidesFormatted;
+                    // Initialize the entry for this database
+                    var proteaseResults = new ConcurrentDictionary<string, Dictionary<Protein, List<InSilicoPep>>>();
+                    concurrentPeptideByFile[database.FileName] = proteaseResults;
+
+                    string databaseFileName = database.FileName;
+                    List<Protein> proteinsForDigestion = proteins;
+
+                    // Process each protease sequentially within each database
+                    // (inner batch methods handle parallelism)
+                    foreach (var protease in DigestionParameters.ProteasesForDigestion)
+                    {
+                        Status("Digesting Proteins...", "digestDbs");
+
+                        var peptides = DigestDatabase(proteinsForDigestion, protease, DigestionParameters);
+                        var peptidesFormatted = DeterminePeptideStatus(databaseFileName, peptides, DigestionParameters);
+
+                        proteaseResults[protease.Name] = peptidesFormatted;
+                    }
+                });
+
+                // Convert concurrent dictionary back to regular dictionary
+                foreach (var dbEntry in concurrentPeptideByFile)
+                {
+                    PeptideByFile[dbEntry.Key] = new Dictionary<string, Dictionary<Protein, List<InSilicoPep>>>(dbEntry.Value);
                 }
-            });
 
-            // Convert concurrent dictionary back to regular dictionary
-            foreach (var dbEntry in concurrentPeptideByFile)
+                Status("Writing Peptide Output...", "peptides");
+                WritePeptidesToTsv(PeptideByFile, OutputFolder, DigestionParameters);
+                SequenceCoverageByProtease = CalculateProteinSequenceCoverage(PeptideByFile);
+                MyTaskResults myRunResults = new MyTaskResults(this);
+                Status("Writing Results Summary...", "summary");
+
+                return myRunResults;
+            }
+            finally
             {
-                PeptideByFile[dbEntry.Key] = new Dictionary<string, Dictionary<Protein, List<InSilicoPep>>>(dbEntry.Value);
+                // Clean up predictor pool after run completes
+                DisposePredictorPool();
+            }
+        }
+
+        public override MyTaskResults RunSpecific(MyTaskResults digestionResults, List<string> peptideFilePaths)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #region Protein Loading
+
+        /// <summary>
+        /// Load proteins from XML or FASTA databases and keep them associated with the database file name.
+        /// </summary>
+        protected List<Protein> LoadProteins(DbForDigestion database)
+        {
+            List<string> dbErrors = new List<string>();
+            List<Protein> proteinList = new List<Protein>();
+
+            string theExtension = Path.GetExtension(database.FilePath).ToLowerInvariant();
+            bool compressed = theExtension.EndsWith("gz");
+            theExtension = compressed
+                ? Path.GetExtension(Path.GetFileNameWithoutExtension(database.FilePath)).ToLowerInvariant()
+                : theExtension;
+
+            if (theExtension.Equals(".fasta") || theExtension.Equals(".fa"))
+            {
+                proteinList = ProteinDbLoader.LoadProteinFasta(
+                    database.FilePath, true, DecoyType.None, false, out dbErrors,
+                    ProteinDbLoader.UniprotAccessionRegex,
+                    ProteinDbLoader.UniprotFullNameRegex,
+                    ProteinDbLoader.UniprotFullNameRegex,
+                    ProteinDbLoader.UniprotGeneNameRegex,
+                    ProteinDbLoader.UniprotOrganismRegex, -1);
+            }
+            else
+            {
+                List<string> modTypesToExclude = new List<string>();
+                proteinList = ProteinDbLoader.LoadProteinXML(
+                    database.FilePath, true, DecoyType.None, GlobalVariables.AllModsKnown,
+                    false, modTypesToExclude, out Dictionary<string, Modification> um, -1, 4, 1);
             }
 
-            Status("Writing Peptide Output...", "peptides");
-            WritePeptidesToTsv(PeptideByFile, OutputFolder, DigestionParameters);
-            SequenceCoverageByProtease = CalculateProteinSequenceCoverage(PeptideByFile);
-            MyTaskResults myRunResults = new MyTaskResults(this);
-            Status("Writing Results Summary...", "summary");
+            if (!proteinList.Any())
+            {
+                Warn("Warning: No protein entries were found in the database");
+                return new List<Protein>();
+            }
 
-            return myRunResults;
-        }
-        // Load proteins from XML or FASTA databases and keep them associated with the database file name from which they came from
-        protected List<Protein> LoadProteins(DbForDigestion database)
-        {                        
-                List<string> dbErrors = new List<string>();
-                List<Protein> proteinList = new List<Protein>();
-                
-                string theExtension = Path.GetExtension(database.FilePath).ToLowerInvariant();
-                bool compressed = theExtension.EndsWith("gz"); // allows for .bgz and .tgz, too which are used on occasion
-                theExtension = compressed ? Path.GetExtension(Path.GetFileNameWithoutExtension(database.FilePath)).ToLowerInvariant() : theExtension;
-
-                if (theExtension.Equals(".fasta") || theExtension.Equals(".fa"))
-                {
-                    proteinList = ProteinDbLoader.LoadProteinFasta(database.FilePath, true, DecoyType.None, false, out dbErrors, ProteinDbLoader.UniprotAccessionRegex,
-                        ProteinDbLoader.UniprotFullNameRegex, ProteinDbLoader.UniprotFullNameRegex, ProteinDbLoader.UniprotGeneNameRegex,
-                        ProteinDbLoader.UniprotOrganismRegex,  -1);
-                    if (!proteinList.Any())
-                    {
-                        Warn("Warning: No protein entries were found in the database");
-                        return new List<Protein>() { };
-                    }
-                    else
-                    {
-                        return proteinList;
-                    }
-
-                }
-                else
-                {
-                    List<string> modTypesToExclude = new List<string> { };
-                    proteinList = ProteinDbLoader.LoadProteinXML(database.FilePath, true, DecoyType.None, GlobalVariables.AllModsKnown, false, modTypesToExclude,
-                        out Dictionary<string, Modification> um, -1, 4, 1);
-                    if (!proteinList.Any())
-                    {
-                        Warn("Warning: No protein entries were found in the database");
-                        return new List<Protein>() { };
-                }
-                    else
-                    {
-                        return proteinList;
-                    }
-                }
-            
-            
+            return proteinList;
         }
 
-        //determine if a peptide is unique or shared. Also generates in silico peptide objects
+        #endregion
+
+        #region Peptide Status Determination
+
         /// <summary>
         /// Determines if each peptide is unique (maps to one protein) or shared (maps to multiple proteins).
-        /// Also calculates physicochemical properties (hydrophobicity, electrophoretic mobility) and 
-        /// generates InSilicoPep objects for downstream analysis.
+        /// Also calculates physicochemical properties and generates InSilicoPep objects.
         /// </summary>
-        /// <param name="databaseName">Name of the source database file</param>
-        /// <param name="databasePeptides">Dictionary mapping proteins to their digested peptides</param>
-        /// <param name="userParams">User-specified digestion parameters</param>
-        /// <returns>Dictionary mapping proteins to their processed InSilicoPep objects</returns>
-        Dictionary<Protein, List<InSilicoPep>> DeterminePeptideStatus(
-            string databaseName, 
-            Dictionary<Protein, List<PeptideWithSetModifications>> databasePeptides, 
+        private Dictionary<Protein, List<InSilicoPep>> DeterminePeptideStatus(
+            string databaseName,
+            Dictionary<Protein, List<PeptideWithSetModifications>> databasePeptides,
             Parameters userParams)
         {
-            // ============================================================================
             // PHASE 1: Determine uniqueness for all peptide sequences
-            // ============================================================================
-    
-            // Flatten all peptides to determine which sequences are unique vs shared
             var allPeptides = databasePeptides
                 .SelectMany(kvp => kvp.Value)
                 .ToList();
 
-            // Group by sequence to determine uniqueness
             var peptideGroups = userParams.TreatModifiedPeptidesAsDifferent
                 ? allPeptides.GroupBy(p => p.FullSequence)
                 : allPeptides.GroupBy(p => p.BaseSequence);
 
-            // Build lookup: sequence -> isUnique (maps to exactly one protein)
             var uniquenessLookup = peptideGroups.ToDictionary(
                 group => group.Key,
                 group => group.Select(p => p.Protein).Distinct().Count() == 1
             );
 
-            // ============================================================================
-            // PHASE 2: Batch calculate hydrophobicity and electrophoretic mobility
-            // ============================================================================
-    
+            // PHASE 2: Batch calculate physicochemical properties
             var hydrophobicityValues = BatchCalculateHydrophobicity(allPeptides);
             var mobilityValues = BatchCalculateElectrophoreticMobility(allPeptides);
             var retentionTimesChronologer = BatchCalculateRetentionTimesChronologer(allPeptides);
 
-            // Create a lookup from peptide to its calculated values
             var peptideToIndex = new Dictionary<PeptideWithSetModifications, int>();
-
             for (int i = 0; i < allPeptides.Count; i++)
             {
                 peptideToIndex[allPeptides[i]] = i;
             }
 
-            // ============================================================================
-            // PHASE 3: Build InSilicoPep objects - process protein by protein to maintain order
-            // ============================================================================
-    
+            // PHASE 3: Build InSilicoPep objects
             var inSilicoPeptides = new Dictionary<Protein, List<InSilicoPep>>();
 
             foreach (var proteinEntry in databasePeptides)
@@ -199,17 +224,11 @@ namespace Tasks
 
                 foreach (var peptide in proteinEntry.Value)
                 {
-                    // Look up uniqueness
-                    string sequenceKey = userParams.TreatModifiedPeptidesAsDifferent 
-                        ? peptide.FullSequence 
+                    string sequenceKey = userParams.TreatModifiedPeptidesAsDifferent
+                        ? peptide.FullSequence
                         : peptide.BaseSequence;
                     bool isUnique = uniquenessLookup[sequenceKey];
-
-                    // Get pre-calculated values
                     int index = peptideToIndex[peptide];
-
-                    // In the DeterminePeptideStatus method, update the InSilicoPep constructor call:
-                    // Replace this section (around line 190-200):
 
                     var inSilicoPep = new InSilicoPep(
                         peptide.BaseSequence,
@@ -219,7 +238,7 @@ namespace Tasks
                         isUnique,
                         hydrophobicityValues[index],
                         mobilityValues[index],
-                        retentionTimesChronologer[index],  // Add this new parameter
+                        retentionTimesChronologer[index],
                         peptide.Length,
                         peptide.MonoisotopicMass,
                         databaseName,
@@ -236,10 +255,7 @@ namespace Tasks
                 inSilicoPeptides[protein] = peptideList;
             }
 
-            // ============================================================================
             // PHASE 4: Handle proteins with no peptides
-            // ============================================================================
-    
             foreach (var protein in databasePeptides.Keys.Where(p => !inSilicoPeptides.ContainsKey(p)))
             {
                 inSilicoPeptides[protein] = new List<InSilicoPep>();
@@ -248,99 +264,97 @@ namespace Tasks
             return inSilicoPeptides;
         }
 
-        //Shared Chronologer predictor pool and synchronization primitives for thread-safe access across all parallel workers
-        private static readonly object ChronologerLock = new object();
-        private static ConcurrentBag<ChronologerRetentionTimePredictor> _predictorPool;
-        private static int _poolSize;
-        private static int _predictorsCreated;
+        #endregion
+
+        #region Chronologer Predictor Pool Management
 
         /// <summary>
-        /// Initializes the shared Chronologer predictor pool if not already created.
+        /// Initializes the predictor pool with a fixed size based on InnerParallelism.
+        /// Called once per run, not resizable to avoid race conditions.
         /// </summary>
-        private static void EnsurePredictorPoolInitialized(int desiredSize)
+        private void InitializePredictorPool()
         {
-            if (_predictorPool != null && _poolSize >= desiredSize)
-                return;
-
-            lock (ChronologerLock)
+            lock (_predictorLock)
             {
-                if (_predictorPool != null && _poolSize >= desiredSize)
+                if (_predictorPool != null)
                     return;
 
-                // Dispose existing pool if resizing
-                if (_predictorPool != null)
-                {
-                    while (_predictorPool.TryTake(out var old))
-                        (old as IDisposable)?.Dispose();
-                }
-
                 _predictorPool = new ConcurrentBag<ChronologerRetentionTimePredictor>();
-                _poolSize = desiredSize;
-                _predictorsCreated = 0;
 
                 // Pre-create predictors sequentially to avoid file access conflicts
-                for (int i = 0; i < desiredSize; i++)
+                for (int i = 0; i < InnerParallelism; i++)
                 {
                     _predictorPool.Add(new ChronologerRetentionTimePredictor());
-                    _predictorsCreated++;
                 }
+            }
+        }
+
+        /// <summary>
+        /// Disposes all predictors in the pool.
+        /// </summary>
+        private void DisposePredictorPool()
+        {
+            lock (_predictorLock)
+            {
+                if (_predictorPool == null)
+                    return;
+
+                while (_predictorPool.TryTake(out var predictor))
+                {
+                    if (predictor is IDisposable disposable)
+                    {
+                        disposable.Dispose();
+                    }
+                }
+
+                _predictorPool = null;
             }
         }
 
         /// <summary>
         /// Checks out a predictor from the pool. Blocks if none available.
         /// </summary>
-        private static ChronologerRetentionTimePredictor CheckoutPredictor()
+        private ChronologerRetentionTimePredictor CheckoutPredictor()
         {
-            ChronologerRetentionTimePredictor predictor;
-            
-            // Spin-wait with backoff until a predictor becomes available
+            if (_predictorPool == null)
+                throw new InvalidOperationException("Predictor pool not initialized.");
+
             SpinWait spinner = default;
+            ChronologerRetentionTimePredictor? predictor;
             while (!_predictorPool.TryTake(out predictor))
             {
                 spinner.SpinOnce();
             }
-            
+
             return predictor;
         }
 
         /// <summary>
         /// Returns a predictor to the pool for reuse.
         /// </summary>
-        private static void ReturnPredictor(ChronologerRetentionTimePredictor predictor)
+        private void ReturnPredictor(ChronologerRetentionTimePredictor predictor)
         {
-            _predictorPool.Add(predictor);
+            _predictorPool?.Add(predictor);
         }
+
+        #endregion
+
+        #region Batch Calculations
 
         /// <summary>
         /// Batch calculates Chronologer-predicted retention times for a collection of peptides.
-        /// Uses a thread-safe predictor pool with checkout/return semantics to ensure each
-        /// predictor is used by at most one worker at a time across all concurrent callers.
         /// </summary>
-        /// <param name="peptides">Collection of peptides to process</param>
-        /// <returns>
-        /// Array of predicted retention time values in the same order as input peptides.
-        /// Returns -1 for peptides where prediction fails.
-        /// </returns>
         private double[] BatchCalculateRetentionTimesChronologer(List<PeptideWithSetModifications> peptides)
         {
             var results = new double[peptides.Count];
-
             if (peptides.Count == 0) return results;
 
-            // Use inner parallelism, but also limited by pool size and peptide count
-            int threadCount = Math.Min(InnerParallelism, Math.Min(_poolSize, peptides.Count));
-            if (threadCount < 1) threadCount = 1;
+            int threadCount = Math.Min(InnerParallelism, peptides.Count);
 
-            // Ensure pool has enough predictors
-            EnsurePredictorPoolInitialized(threadCount);
-
-            // Run predictions in parallel - each iteration checks out/returns a predictor
             Parallel.For(0, peptides.Count,
                 new ParallelOptions { MaxDegreeOfParallelism = threadCount },
                 i =>
                 {
-                    // Checkout: get exclusive access to a predictor
                     var predictor = CheckoutPredictor();
                     try
                     {
@@ -349,7 +363,6 @@ namespace Tasks
                     }
                     finally
                     {
-                        // Return: make predictor available to other workers
                         ReturnPredictor(predictor);
                     }
                 }
@@ -359,21 +372,14 @@ namespace Tasks
         }
 
         /// <summary>
-        /// Batch calculates hydrophobicity (retention time prediction) for a collection of peptides.
-        /// This method is designed to be easily replaced with a batch-based ML prediction model.
+        /// Batch calculates hydrophobicity for a collection of peptides.
         /// </summary>
-        /// <param name="peptides">Collection of peptides to process</param>
-        /// <returns>Array of hydrophobicity values in the same order as input peptides</returns>
         private double[] BatchCalculateHydrophobicity(List<PeptideWithSetModifications> peptides)
         {
             var results = new double[peptides.Count];
             if (peptides.Count == 0) return results;
 
-            // Use inner parallelism to avoid oversubscription when called from outer parallel loop
-            var options = new ParallelOptions 
-            { 
-                MaxDegreeOfParallelism = InnerParallelism 
-            };
+            var options = new ParallelOptions { MaxDegreeOfParallelism = InnerParallelism };
 
             Parallel.For(0, peptides.Count,
                 options,
@@ -391,19 +397,13 @@ namespace Tasks
 
         /// <summary>
         /// Batch calculates electrophoretic mobility for a collection of peptides.
-        /// Uses the Cifuentes mobility equation based on charge and mass.
         /// </summary>
-        /// <param name="peptides">Collection of peptides to process</param>
-        /// <returns>Array of electrophoretic mobility values in the same order as input peptides</returns>
         private double[] BatchCalculateElectrophoreticMobility(List<PeptideWithSetModifications> peptides)
         {
             var results = new double[peptides.Count];
             if (peptides.Count == 0) return results;
 
-            var options = new ParallelOptions 
-            { 
-                MaxDegreeOfParallelism = InnerParallelism 
-            };
+            var options = new ParallelOptions { MaxDegreeOfParallelism = InnerParallelism };
 
             Parallel.For(0, peptides.Count, options, i =>
             {
@@ -412,10 +412,12 @@ namespace Tasks
 
             return results;
         }
-        //calculate electrophoretic mobility of a peptide
+
+        /// <summary>
+        /// Calculates electrophoretic mobility of a peptide using the Cifuentes equation.
+        /// </summary>
         private static double GetCifuentesMobility(PeptideWithSetModifications pwsm)
         {
-            // Count K, R, H in a single pass through the sequence (instead of 3 separate LINQ calls)
             int kCount = 0, rCount = 0, hCount = 0;
             foreach (char c in pwsm.BaseSequence)
             {
@@ -428,15 +430,11 @@ namespace Tasks
             }
 
             int charge = 1 + kCount + rCount + hCount - CountModificationsThatShiftMobility(pwsm.AllModsOneIsNterminus.Values);
+            double mobility = Math.Log(1 + 0.35 * charge) / Math.Pow(pwsm.MonoisotopicMass, 0.411);
 
-            double mobility = (Math.Log(1 + 0.35 * (double)charge)) / Math.Pow(pwsm.MonoisotopicMass, 0.411);
-            if (Double.IsNaN(mobility))
-            {
-                mobility = 0;
-            }
-            return mobility;
+            return double.IsNaN(mobility) ? 0 : mobility;
         }
-        // Static HashSet for O(1) lookup - created once, reused for all calls
+
         private static readonly HashSet<string> ShiftingModifications = new HashSet<string>(StringComparer.Ordinal)
         {
             "Acetylation", "Ammonia loss", "Carbamyl", "Deamidation", "Formylation",
@@ -446,87 +444,48 @@ namespace Tasks
             "N-acetyltyrosine", "N-acetylvaline", "Phosphorylation", "Phosphoserine",
             "Phosphothreonine", "Phosphotyrosine", "Sulfonation"
         };
+
         public static int CountModificationsThatShiftMobility(IEnumerable<Modification> modifications)
         {
             return modifications.Count(mod =>
                 mod.OriginalId != null && ShiftingModifications.Contains(mod.OriginalId));
         }
+
+        #endregion
+
+        #region Sequence Coverage Calculation
+
         /// <summary>
         /// Calculates protein sequence coverage for each protease across all databases.
-        /// 
-        /// Sequence coverage is defined as the percentage of residues in a protein's sequence
-        /// that are covered by at least one peptide from the digestion.
-        /// 
-        /// Returns both total coverage (all peptides) and unique coverage (unique peptides only).
-        /// Coverage values are returned as percentages (0-100), rounded to 2 decimal places.
         /// </summary>
-        /// <param name="peptideByFile">
-        /// Hierarchical dictionary structure:
-        ///   Database filename -> Protease name -> Protein object -> List of InSilicoPep peptides
-        /// </param>
-        /// <returns>
-        /// Dictionary structure:
-        ///   Protease name -> Protein object -> (total coverage %, unique coverage %)
-        /// </returns>
-        /// <remarks>
-        /// Algorithm:
-        /// 1. Flatten peptides from all databases, grouped by protease
-        /// 2. Build a mapping from protein accession strings to Protein objects
-        /// 3. For each protease, group peptides by protein accession
-        /// 4. For each protein:
-        ///    a. Track which residue positions are covered by any peptide
-        ///    b. Track which residue positions are covered by UNIQUE peptides only
-        ///    c. Calculate coverage as: (covered residues / protein length) * 100
-        /// 5. Return the coverage percentages for each protein-protease combination
-        /// </remarks>
         private Dictionary<string, Dictionary<Protein, (double, double)>> CalculateProteinSequenceCoverage(
             Dictionary<string, Dictionary<string, Dictionary<Protein, List<InSilicoPep>>>> peptideByFile)
         {
-            // ============================================================================
-            // PHASE 1: Aggregate peptides from all databases, organized by protease
-            // ============================================================================
+            // PHASE 1: Aggregate peptides from all databases by protease
+            var allDatabasePeptidesByProtease = new Dictionary<string, List<InSilicoPep>>();
+            var accessionToProtein = new Dictionary<string, Protein>();
 
-            // Key: protease name, Value: all peptides digested by that protease (across all databases)
-            Dictionary<string, List<InSilicoPep>> allDatabasePeptidesByProtease = new Dictionary<string, List<InSilicoPep>>();
-
-            // Maps protein accession string -> actual Protein object
-            // This is needed because InSilicoPep stores protein accession as a string,
-            // but we need to return Protein objects in the result and access their Length property
-            Dictionary<string, Protein> accessionToProtein = new Dictionary<string, Protein>();
-
-            // Iterate through each database file
             foreach (var database in peptideByFile)
             {
-                // Iterate through each protease used on this database
                 foreach (var protease in database.Value)
                 {
                     string proteaseName = protease.Key;
 
-                    // If we've already seen this protease (from another database), add to existing list
                     if (allDatabasePeptidesByProtease.ContainsKey(proteaseName))
                     {
-                        // Add peptides from each protein in this database
                         foreach (var proteinEntry in protease.Value)
                         {
-                            Protein protein = proteinEntry.Key;
-                            List<InSilicoPep> peptides = proteinEntry.Value;
-
-                            allDatabasePeptidesByProtease[proteaseName].AddRange(peptides);
-
-                            // Store the accession -> Protein mapping
-                            // (overwrites if same accession appears in multiple databases, which is fine)
-                            accessionToProtein[protein.Accession] = protein;
+                            allDatabasePeptidesByProtease[proteaseName].AddRange(proteinEntry.Value);
+                            accessionToProtein[proteinEntry.Key.Accession] = proteinEntry.Key;
                         }
                     }
                     else
                     {
-                        // First time seeing this protease - create new entry
                         allDatabasePeptidesByProtease.Add(
                             proteaseName,
                             protease.Value.SelectMany(p => p.Value).ToList()
                         );
 
-                        // Store protein mappings for all proteins digested by this protease
                         foreach (var proteinEntry in protease.Value)
                         {
                             accessionToProtein[proteinEntry.Key.Accession] = proteinEntry.Key;
@@ -535,76 +494,38 @@ namespace Tasks
                 }
             }
 
-            // ============================================================================
             // PHASE 2: Calculate coverage for each protease-protein combination
-            // ============================================================================
+            var proteinSequenceCoverageByProtease = new Dictionary<string, Dictionary<Protein, (double, double)>>();
 
-            // Result structure: Protease name -> Protein -> (total coverage %, unique coverage %)
-            Dictionary<string, Dictionary<Protein, (double, double)>> proteinSequenceCoverageByProtease =
-                new Dictionary<string, Dictionary<Protein, (double, double)>>();
-
-            // Process each protease
             foreach (var protease in allDatabasePeptidesByProtease)
             {
                 string proteaseName = protease.Key;
-                List<InSilicoPep> peptidesForProtease = protease.Value;
+                var peptidesForProtease = protease.Value;
 
-                // ------------------------------------------------------------------------
-                // Group peptides by their parent protein accession
-                // NOTE: InSilicoPep.Protein is a STRING (the accession), not a Protein object!
-                // ------------------------------------------------------------------------
                 var peptidesByProteinAccession = peptidesForProtease
-                    .GroupBy(p => p.Protein)  // p.Protein is the accession string
-                    .ToDictionary(
-                        group => group.Key,      // Key is the accession string
-                        group => group.ToList()  // Value is list of peptides for that protein
-                    );
+                    .GroupBy(p => p.Protein)
+                    .ToDictionary(group => group.Key, group => group.ToList());
 
-                // Storage for coverage results for this protease
-                Dictionary<Protein, (double, double)> sequenceCoverages =
-                    new Dictionary<Protein, (double, double)>();
+                var sequenceCoverages = new Dictionary<Protein, (double, double)>();
 
-                // Calculate coverage for each protein
                 foreach (var proteinGroup in peptidesByProteinAccession)
                 {
                     string proteinAccession = proteinGroup.Key;
-                    List<InSilicoPep> peptidesForThisProtein = proteinGroup.Value;
+                    var peptidesForThisProtein = proteinGroup.Value;
 
-                    // ------------------------------------------------------------------------
-                    // CRITICAL: Look up the actual Protein object to get the correct sequence length
-                    // The proteinAccession is a STRING, so proteinAccession.Length would give us
-                    // the length of the accession string (e.g., "P68871" = 7), NOT the protein length!
-                    // ------------------------------------------------------------------------
-                    if (!accessionToProtein.TryGetValue(proteinAccession, out Protein actualProtein))
-                    {
-                        // Skip if we can't find the protein (shouldn't happen, but defensive)
+                    if (!accessionToProtein.TryGetValue(proteinAccession, out Protein? actualProtein))
                         continue;
-                    }
 
-                    // Get the actual protein sequence length (e.g., 147 for HBB_HUMAN)
                     int proteinSequenceLength = actualProtein.Length;
-
-                    // ------------------------------------------------------------------------
-                    // Track which residue positions (1-based) are covered by peptides
-                    // Using HashSet ensures each position is only counted once, even if
-                    // multiple peptides cover the same residue
-                    // ------------------------------------------------------------------------
-                    HashSet<int> coveredResidues = new HashSet<int>();       // All peptides
-                    HashSet<int> coveredResiduesUnique = new HashSet<int>(); // Unique peptides only
-
-                    // Use HashSet to avoid counting duplicate peptides multiple times
+                    var coveredResidues = new HashSet<int>();
+                    var coveredResiduesUnique = new HashSet<int>();
                     var uniquePeptideSet = peptidesForThisProtein.ToHashSet();
 
-                    // For each peptide, mark all residues it covers
                     foreach (var peptide in uniquePeptideSet)
                     {
-                        // peptide.StartResidue and EndResidue are 1-based positions in the protein
                         for (int residuePosition = peptide.StartResidue; residuePosition <= peptide.EndResidue; residuePosition++)
                         {
-                            // This residue is covered by at least one peptide
                             coveredResidues.Add(residuePosition);
-
-                            // If the peptide is unique (maps to only one protein), also add to unique coverage
                             if (peptide.Unique)
                             {
                                 coveredResiduesUnique.Add(residuePosition);
@@ -612,50 +533,84 @@ namespace Tasks
                         }
                     }
 
-                    // ------------------------------------------------------------------------
-                    // Calculate coverage percentages
-                    // Coverage = (number of covered residues / total residues) * 100
-                    // ------------------------------------------------------------------------
-                    double totalCoveragePercent = (double)coveredResidues.Count / proteinSequenceLength * 100.0;
-                    double uniqueCoveragePercent = (double)coveredResiduesUnique.Count / proteinSequenceLength * 100.0;
+                    double totalCoveragePercent = Math.Round((double)coveredResidues.Count / proteinSequenceLength * 100.0, 2);
+                    double uniqueCoveragePercent = Math.Round((double)coveredResiduesUnique.Count / proteinSequenceLength * 100.0, 2);
 
-                    // Round to 2 decimal places for cleaner display
-                    totalCoveragePercent = Math.Round(totalCoveragePercent, 2);
-                    uniqueCoveragePercent = Math.Round(uniqueCoveragePercent, 2);
-
-                    // Store the results using the actual Protein object as the key
                     sequenceCoverages.Add(actualProtein, (totalCoveragePercent, uniqueCoveragePercent));
                 }
 
-                // Add this protease's coverage results to the final output
                 proteinSequenceCoverageByProtease.Add(proteaseName, sequenceCoverages);
             }
 
             return proteinSequenceCoverageByProtease;
         }
-        private void Warn(string v)
+
+        #endregion
+
+        #region Database Digestion
+
+        /// <summary>
+        /// Digests proteins for each database using the protease and settings provided.
+        /// </summary>
+        protected Dictionary<Protein, List<PeptideWithSetModifications>> DigestDatabase(
+            List<Protein> proteinsFromDatabase,
+            Protease protease,
+            Parameters userDigestionParams)
         {
-            DigestionWarnHandler?.Invoke(null, new StringEventArgs(v, null));
+            var dp = new DigestionParams(
+                protease: protease.Name,
+                maxMissedCleavages: userDigestionParams.NumberOfMissedCleavagesAllowed,
+                minPeptideLength: userDigestionParams.MinPeptideLengthAllowed,
+                maxPeptideLength: userDigestionParams.MaxPeptideLengthAllowed);
+
+            var peptidesForProtein = new Dictionary<Protein, List<PeptideWithSetModifications>>(proteinsFromDatabase.Count);
+
+            foreach (var protein in proteinsFromDatabase)
+            {
+                var peptides = protein.Digest(dp, userDigestionParams.fixedMods, userDigestionParams.variableMods).ToList();
+
+                // Apply mass filters
+                if (userDigestionParams.MinPeptideMassAllowed != -1)
+                {
+                    peptides = peptides.Where(p => p.MonoisotopicMass > userDigestionParams.MinPeptideMassAllowed).ToList();
+                }
+                if (userDigestionParams.MaxPeptideMassAllowed != -1)
+                {
+                    peptides = peptides.Where(p => p.MonoisotopicMass < userDigestionParams.MaxPeptideMassAllowed).ToList();
+                }
+
+                peptidesForProtein.Add(protein, peptides);
+            }
+
+            return peptidesForProtein;
         }
 
-        public override MyTaskResults RunSpecific(MyTaskResults digestionResults, List<string> peptideFilePaths)
-        {
-            throw new NotImplementedException();
-        }
-        
-        // write peptides to tsv files as results
-        protected static void WritePeptidesToTsv(Dictionary<string, Dictionary<string, Dictionary<Protein, List<InSilicoPep>>>> peptideByFile, string filePath, Parameters userParams)
-        {
-            string tab = "\t";
+        #endregion
 
-            string header = "Database" + tab + "Protease" + tab + "Base Sequence" + tab + "Full Sequence" + tab + "Previous Amino Acid" + tab +
-                "Next Amino Acid" + tab + "Start Residue" + tab + "End Residue" + tab + "Length" + tab + "Molecular Weight" + tab + "Protein Accession" + tab + "Protein Name" + tab + "Unique Peptide (in this database)" + tab + "Unique Peptide (in all databases)" + tab + "Peptide sequence exclusive to this Database" + tab +
-                "Hydrophobicity" + tab + "Electrophoretic Mobility" + tab + "Chronologer Retention Time";
-            List<InSilicoPep> allPeptides = new List<InSilicoPep>();
-            Dictionary<string, Dictionary<string, Dictionary<Protein, List<InSilicoPep>>>> peptideByFileUpdated = new Dictionary<string, Dictionary<string, Dictionary<Protein, List<InSilicoPep>>>>();
+        #region TSV Output
+
+        /// <summary>
+        /// Writes peptides to TSV files as results.
+        /// </summary>
+        protected static void WritePeptidesToTsv(
+            Dictionary<string, Dictionary<string, Dictionary<Protein, List<InSilicoPep>>>> peptideByFile,
+            string filePath,
+            Parameters userParams)
+        {
+            const string tab = "\t";
+            string header = string.Join(tab,
+                "Database", "Protease", "Base Sequence", "Full Sequence", "Previous Amino Acid",
+                "Next Amino Acid", "Start Residue", "End Residue", "Length", "Molecular Weight",
+                "Protein Accession", "Protein Name", "Unique Peptide (in this database)",
+                "Unique Peptide (in all databases)", "Peptide sequence exclusive to this Database",
+                "Hydrophobicity", "Electrophoretic Mobility", "Chronologer Retention Time");
+
+            var allPeptides = new List<InSilicoPep>();
+
             if (peptideByFile.Count > 1)
             {
-                Dictionary<string, List<InSilicoPep>> allDatabasePeptidesByProtease = new Dictionary<string, List<InSilicoPep>>();
+                var allDatabasePeptidesByProtease = new Dictionary<string, List<InSilicoPep>>();
+
                 foreach (var database in peptideByFile)
                 {
                     foreach (var protease in database.Value)
@@ -670,71 +625,40 @@ namespace Tasks
                         else
                         {
                             allDatabasePeptidesByProtease.Add(protease.Key, protease.Value.SelectMany(p => p.Value).ToList());
-                        }                        
+                        }
                     }
                 }
+
                 foreach (var protease in allDatabasePeptidesByProtease)
                 {
-                    Dictionary<string, List<InSilicoPep>> peptidesToProteins = new Dictionary<string, List<InSilicoPep>>();
-                    if (userParams.TreatModifiedPeptidesAsDifferent)
-                    {
-                        peptidesToProteins = protease.Value.GroupBy(p => p.FullSequence).ToDictionary(group => group.Key, group => group.ToList());
-                    }
-                    else
-                    {
-                        peptidesToProteins = protease.Value.GroupBy(p => p.BaseSequence).ToDictionary(group => group.Key, group => group.ToList());
-                    }
+                    var peptidesToProteins = userParams.TreatModifiedPeptidesAsDifferent
+                        ? protease.Value.GroupBy(p => p.FullSequence).ToDictionary(g => g.Key, g => g.ToList())
+                        : protease.Value.GroupBy(p => p.BaseSequence).ToDictionary(g => g.Key, g => g.ToList());
 
-                    var unique = peptidesToProteins.Where(p => p.Value.Select(p => p.Protein).Distinct().Count() == 1).ToList();
-                    var shared = peptidesToProteins.Where(p => p.Value.Select(p => p.Protein).Distinct().Count() > 1).ToList();
-                    
+                    var unique = peptidesToProteins.Where(p => p.Value.Select(x => x.Protein).Distinct().Count() == 1).ToList();
+                    var shared = peptidesToProteins.Where(p => p.Value.Select(x => x.Protein).Distinct().Count() > 1).ToList();
+
                     foreach (var entry in unique)
                     {
-                        if (entry.Value.Select(p=>p.Database).Distinct().ToList().Count >1)
+                        bool multipleDbsForSequence = entry.Value.Select(p => p.Database).Distinct().Count() > 1;
+                        foreach (var peptide in entry.Value)
                         {
-                            foreach (var peptide in entry.Value)
-                            {
-                                peptide.UniqueAllDbs = false;
-                                peptide.SeqOnlyInThisDb = false;
-                                allPeptides.Add(peptide);
-
-                            }
+                            peptide.UniqueAllDbs = !multipleDbsForSequence;
+                            peptide.SeqOnlyInThisDb = !multipleDbsForSequence;
+                            allPeptides.Add(peptide);
                         }
-                        else
-                        {
-                            foreach (var peptide in entry.Value)
-                            {
-                                peptide.UniqueAllDbs = true;
-                                peptide.SeqOnlyInThisDb = true;
-                                allPeptides.Add(peptide);
-
-                            }
-                        }
-                                             
                     }
+
                     foreach (var entry in shared)
                     {
-
-                        if (entry.Value.Select(p => p.Database).Distinct().Count() == 1)
+                        bool singleDb = entry.Value.Select(p => p.Database).Distinct().Count() == 1;
+                        foreach (var peptide in entry.Value)
                         {
-                            foreach (var peptide in entry.Value)
-                            {
-                                peptide.UniqueAllDbs = false;
-                                peptide.SeqOnlyInThisDb = true;
-                                allPeptides.Add(peptide);                                
-                            }
+                            peptide.UniqueAllDbs = false;
+                            peptide.SeqOnlyInThisDb = singleDb;
+                            allPeptides.Add(peptide);
                         }
-                        else
-                        {
-                            foreach (var peptide in entry.Value)
-                            {
-                                peptide.UniqueAllDbs = false;
-                                peptide.SeqOnlyInThisDb = false;
-                                allPeptides.Add(peptide);                                
-                            }
-                        }                        
                     }
-                    
                 }
             }
             else
@@ -744,86 +668,92 @@ namespace Tasks
                     foreach (var protease in database.Value)
                     {
                         foreach (var protein in protease.Value)
-                        {                           
+                        {
                             foreach (var peptide in protein.Value)
                             {
                                 peptide.UniqueAllDbs = peptide.Unique;
-                                peptide.SeqOnlyInThisDb = true;                                
+                                peptide.SeqOnlyInThisDb = true;
                                 allPeptides.Add(peptide);
-                            }                            
+                            }
                         }
                     }
                 }
             }
-                       
-            
-            var numberOfPeptides = allPeptides.Count();
+
+            // Write peptides to files (max 1M per file)
+            int numberOfPeptides = allPeptides.Count;
             const int peptidesPerFile = 1000000;
             int numberOfFiles = (int)Math.Ceiling(numberOfPeptides / (double)peptidesPerFile);
-            var peptideIndex = 0;
+            int peptideIndex = 0;
 
             for (int fileCount = 1; fileCount <= numberOfFiles; fileCount++)
             {
                 string outputPath = Path.Combine(filePath, $"ProteaseGuruPeptides_{fileCount}.tsv");
-                using (StreamWriter output = new StreamWriter(outputPath))
-                {
-                    output.WriteLine(header);
+                using var output = new StreamWriter(outputPath);
+                output.WriteLine(header);
 
-                    int peptidesWrittenToThisFile = 0;
-                    while (peptidesWrittenToThisFile < peptidesPerFile && peptideIndex < numberOfPeptides)
-                    {
-                        output.WriteLine(allPeptides[peptideIndex].ToString());
-                        peptideIndex++;
-                        peptidesWrittenToThisFile++;
-                    }
+                int peptidesWrittenToThisFile = 0;
+                while (peptidesWrittenToThisFile < peptidesPerFile && peptideIndex < numberOfPeptides)
+                {
+                    output.WriteLine(allPeptides[peptideIndex].ToString());
+                    peptideIndex++;
+                    peptidesWrittenToThisFile++;
                 }
             }
 
-            List<string> parameters = new List<string>();
-            parameters.Add("Digestion Conditions:");
-            parameters.Add("Database: " + string.Join(',', peptideByFile.Keys));
-            parameters.Add("Proteases: " + string.Join(", ", userParams.ProteasesForDigestion.Select(p => p.Name)));
-            parameters.Add("Max Missed Cleavages: " + userParams.NumberOfMissedCleavagesAllowed);
-            parameters.Add("Min Peptide Length: " + userParams.MinPeptideLengthAllowed);
-            parameters.Add("Max Peptide Length: " + userParams.MaxPeptideLengthAllowed);
-            parameters.Add("Treat modified peptides as different peptides: " + userParams.TreatModifiedPeptidesAsDifferent);
-            parameters.Add("Min Peptide Mass: " + userParams.MinPeptideLengthAllowed);
-            parameters.Add("Max Peptide Mass: " + userParams.MaxPeptideLengthAllowed);
-
-            File.WriteAllLines(filePath + @"\DigestionConditions.txt", parameters);
-            
-        }
-
-        protected void Status(string v, string id)
-        {
-            OutLabelStatusHandler?.Invoke(this, new StringEventArgs(v, new List<string> { id }));
-        }
-
-        //digest proteins for each database using the protease and settings provided
-        protected Dictionary<Protein, List<PeptideWithSetModifications>> DigestDatabase(List<Protein> proteinsFromDatabase,
-            Protease protease, Parameters userDigestionParams)
-        {
-            DigestionParams dp = new DigestionParams(protease: protease.Name, maxMissedCleavages: userDigestionParams.NumberOfMissedCleavagesAllowed,
-                minPeptideLength: userDigestionParams.MinPeptideLengthAllowed, maxPeptideLength: userDigestionParams.MaxPeptideLengthAllowed);
-            Dictionary<Protein, List<PeptideWithSetModifications>> peptidesForProtein = new Dictionary<Protein, List<PeptideWithSetModifications>>(proteinsFromDatabase.Count);
-            foreach (var protein in proteinsFromDatabase)
+            // Write digestion conditions
+            var parameters = new List<string>
             {
-                List<PeptideWithSetModifications> peptides = protein.Digest(dp, userDigestionParams.fixedMods, userDigestionParams.variableMods).ToList();
-                if (userDigestionParams.MaxPeptideMassAllowed != -1 && userDigestionParams.MinPeptideMassAllowed != -1)
-                {
-                    peptides = peptides.Where(p => p.MonoisotopicMass > userDigestionParams.MinPeptideMassAllowed && p.MonoisotopicMass < userDigestionParams.MaxPeptideMassAllowed).ToList();
-                }
-                else if (userDigestionParams.MaxPeptideMassAllowed == -1 && userDigestionParams.MinPeptideMassAllowed != -1)
-                {
-                    peptides = peptides.Where(p => p.MonoisotopicMass > userDigestionParams.MinPeptideMassAllowed).ToList();
-                }
-                else if (userDigestionParams.MaxPeptideMassAllowed != -1 && userDigestionParams.MinPeptideMassAllowed == -1)
-                {
-                    peptides = peptides.Where(p => p.MonoisotopicMass < userDigestionParams.MaxPeptideMassAllowed).ToList();
-                }                
-                peptidesForProtein.Add(protein, peptides);
-            }
-            return peptidesForProtein;
+                "Digestion Conditions:",
+                "Database: " + string.Join(',', peptideByFile.Keys),
+                "Proteases: " + string.Join(", ", userParams.ProteasesForDigestion.Select(p => p.Name)),
+                "Max Missed Cleavages: " + userParams.NumberOfMissedCleavagesAllowed,
+                "Min Peptide Length: " + userParams.MinPeptideLengthAllowed,
+                "Max Peptide Length: " + userParams.MaxPeptideLengthAllowed,
+                "Treat modified peptides as different peptides: " + userParams.TreatModifiedPeptidesAsDifferent,
+                "Min Peptide Mass: " + userParams.MinPeptideMassAllowed,
+                "Max Peptide Mass: " + userParams.MaxPeptideMassAllowed
+            };
+
+            File.WriteAllLines(Path.Combine(filePath, "DigestionConditions.txt"), parameters);
         }
+
+        #endregion
+
+        #region Utility Methods
+
+        private void Warn(string message)
+        {
+            DigestionWarnHandler?.Invoke(null, new StringEventArgs(message, null));
+        }
+
+        protected void Status(string message, string id)
+        {
+            OutLabelStatusHandler?.Invoke(this, new StringEventArgs(message, new List<string> { id }));
+        }
+
+        #endregion
+
+        #region IDisposable Implementation
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (_disposed) return;
+
+            if (disposing)
+            {
+                DisposePredictorPool();
+            }
+
+            _disposed = true;
+        }
+
+        #endregion
     }
 }

--- a/Tasks/DigestionTask.cs
+++ b/Tasks/DigestionTask.cs
@@ -233,82 +233,81 @@ namespace Tasks
 
             return inSilicoPeptides;
         }
-        // Add this static field at the top of the DigestionTask class:
+        // Replace the existing predictor pool implementation (lines ~227-280) with this:
+        
         private static readonly object ChronologerLock = new object();
-        private static ChronologerRetentionTimePredictor[] _sharedPredictorPool;
-        private static int _predictorPoolRefCount;
+        private static ConcurrentBag<ChronologerRetentionTimePredictor> _predictorPool;
+        private static int _poolSize;
+        private static int _predictorsCreated;
 
         /// <summary>
-        /// Initializes the shared Chronologer predictor pool (thread-safe, creates only once).
-        /// Call <see cref="ReleasePredictorPool"/> when done to allow cleanup.
+        /// Initializes the shared Chronologer predictor pool if not already created.
         /// </summary>
-        private static ChronologerRetentionTimePredictor[] GetOrCreatePredictorPool(int threadCount)
+        private static void EnsurePredictorPoolInitialized(int desiredSize)
         {
+            if (_predictorPool != null && _poolSize >= desiredSize)
+                return;
+
             lock (ChronologerLock)
             {
-                if (_sharedPredictorPool == null || _sharedPredictorPool.Length < threadCount)
-                {
-                    // Dispose existing predictors if resizing
-                    DisposePredictorPoolUnsafe();
+                if (_predictorPool != null && _poolSize >= desiredSize)
+                    return;
 
-                    _sharedPredictorPool = new ChronologerRetentionTimePredictor[threadCount];
-                    for (int i = 0; i < threadCount; i++)
-                    {
-                        _sharedPredictorPool[i] = new ChronologerRetentionTimePredictor();
-                    }
+                // Dispose existing pool if resizing
+                if (_predictorPool != null)
+                {
+                    while (_predictorPool.TryTake(out var old))
+                        (old as IDisposable)?.Dispose();
                 }
-                _predictorPoolRefCount++;
-                return _sharedPredictorPool;
-            }
-        }
 
-        /// <summary>
-        /// Releases a reference to the predictor pool. When the last reference is released,
-        /// the pool is disposed to free file handles.
-        /// </summary>
-        private static void ReleasePredictorPool()
-        {
-            lock (ChronologerLock)
-            {
-                _predictorPoolRefCount--;
-                if (_predictorPoolRefCount <= 0)
+                _predictorPool = new ConcurrentBag<ChronologerRetentionTimePredictor>();
+                _poolSize = desiredSize;
+                _predictorsCreated = 0;
+
+                // Pre-create predictors sequentially to avoid file access conflicts
+                for (int i = 0; i < desiredSize; i++)
                 {
-                    DisposePredictorPoolUnsafe();
-                    _predictorPoolRefCount = 0;
+                    _predictorPool.Add(new ChronologerRetentionTimePredictor());
+                    _predictorsCreated++;
                 }
             }
         }
 
         /// <summary>
-        /// Disposes the predictor pool without locking. Must be called within ChronologerLock.
+        /// Checks out a predictor from the pool. Blocks if none available.
         /// </summary>
-        private static void DisposePredictorPoolUnsafe()
+        private static ChronologerRetentionTimePredictor CheckoutPredictor()
         {
-            if (_sharedPredictorPool != null)
+            ChronologerRetentionTimePredictor predictor;
+            
+            // Spin-wait with backoff until a predictor becomes available
+            SpinWait spinner = default;
+            while (!_predictorPool.TryTake(out predictor))
             {
-                foreach (var predictor in _sharedPredictorPool)
-                {
-                    (predictor as IDisposable)?.Dispose();
-                }
-                _sharedPredictorPool = null;
+                spinner.SpinOnce();
             }
+            
+            return predictor;
+        }
+
+        /// <summary>
+        /// Returns a predictor to the pool for reuse.
+        /// </summary>
+        private static void ReturnPredictor(ChronologerRetentionTimePredictor predictor)
+        {
+            _predictorPool.Add(predictor);
         }
 
         /// <summary>
         /// Batch calculates Chronologer-predicted retention times for a collection of peptides.
-        /// Uses a shared, thread-safe predictor pool to avoid file access conflicts when loading
-        /// the Chronologer model. Predictions are parallelized across available processor cores.
+        /// Uses a thread-safe predictor pool with checkout/return semantics to ensure each
+        /// predictor is used by at most one worker at a time across all concurrent callers.
         /// </summary>
         /// <param name="peptides">Collection of peptides to process</param>
         /// <returns>
         /// Array of predicted retention time values in the same order as input peptides.
         /// Returns -1 for peptides where prediction fails.
         /// </returns>
-        /// <remarks>
-        /// The predictor pool is reference-counted and shared across calls to avoid repeatedly
-        /// loading the Chronologer model file. Each worker thread is assigned a unique predictor
-        /// via atomic counter to ensure thread safety without locking during predictions.
-        /// </remarks>
         private double[] BatchCalculateRetentionTimesChronologer(List<PeptideWithSetModifications> peptides)
         {
             var results = new double[peptides.Count];
@@ -318,35 +317,28 @@ namespace Tasks
             int threadCount = Math.Min(Environment.ProcessorCount, peptides.Count);
             if (threadCount < 1) threadCount = 1;
 
-            // Get shared predictor pool (thread-safe creation)
-            var predictorPool = GetOrCreatePredictorPool(threadCount);
+            // Ensure pool has enough predictors
+            EnsurePredictorPoolInitialized(threadCount);
 
-            // Atomic counter to assign unique predictor indices to each worker thread
-            int nextPredictorIndex = -1;
-
-            try
-            {
-                // Run predictions in parallel - each worker gets a unique predictor via atomic counter
-                Parallel.For(0, peptides.Count,
-                    new ParallelOptions { MaxDegreeOfParallelism = threadCount },
-                    // Thread-local init: atomically claim a unique predictor index for this worker
-                    () => Interlocked.Increment(ref nextPredictorIndex) % threadCount,
-                    // Body: use the assigned predictor (no lock needed - each worker has exclusive access)
-                    (i, loopState, predictorIndex) =>
+            // Run predictions in parallel - each iteration checks out/returns a predictor
+            Parallel.For(0, peptides.Count,
+                new ParallelOptions { MaxDegreeOfParallelism = threadCount },
+                i =>
+                {
+                    // Checkout: get exclusive access to a predictor
+                    var predictor = CheckoutPredictor();
+                    try
                     {
-                        var result = predictorPool[predictorIndex].PredictRetentionTime(peptides[i], out _);
+                        var result = predictor.PredictRetentionTime(peptides[i], out _);
                         results[i] = result ?? -1;
-                        return predictorIndex;
-                    },
-                    // Finalizer: nothing to clean up
-                    _ => { }
-                );
-            }
-            finally
-            {
-                // Release reference to allow cleanup when all callers are done
-                ReleasePredictorPool();
-            }
+                    }
+                    finally
+                    {
+                        // Return: make predictor available to other workers
+                        ReturnPredictor(predictor);
+                    }
+                }
+            );
 
             return results;
         }

--- a/Tasks/DigestionTask.cs
+++ b/Tasks/DigestionTask.cs
@@ -1,13 +1,11 @@
 using System.Collections.Concurrent;
 using System.Data;
-using Chromatography.RetentionTimePrediction;
 using Chromatography.RetentionTimePrediction.Chronologer;
 using Engine;
 using Omics.Modifications;
 using Proteomics;
 using Proteomics.ProteolyticDigestion;
 using Proteomics.RetentionTimePrediction;
-using SharpLearning.Common.Interfaces;
 using UsefulProteomicsDatabases;
 
 namespace Tasks
@@ -237,22 +235,103 @@ namespace Tasks
         }
         // Add this static field at the top of the DigestionTask class:
         private static readonly object ChronologerLock = new object();
+        private static ChronologerRetentionTimePredictor[] _sharedPredictorPool;
+        private static int _predictorPoolRefCount;
+
+        /// <summary>
+        /// Initializes the shared Chronologer predictor pool (thread-safe, creates only once).
+        /// Call <see cref="ReleasePredictorPool"/> when done to allow cleanup.
+        /// </summary>
+        private static ChronologerRetentionTimePredictor[] GetOrCreatePredictorPool(int threadCount)
+        {
+            lock (ChronologerLock)
+            {
+                if (_sharedPredictorPool == null || _sharedPredictorPool.Length < threadCount)
+                {
+                    // Dispose existing predictors if resizing
+                    DisposePredictorPoolUnsafe();
+
+                    _sharedPredictorPool = new ChronologerRetentionTimePredictor[threadCount];
+                    for (int i = 0; i < threadCount; i++)
+                    {
+                        _sharedPredictorPool[i] = new ChronologerRetentionTimePredictor();
+                    }
+                }
+                _predictorPoolRefCount++;
+                return _sharedPredictorPool;
+            }
+        }
+
+        /// <summary>
+        /// Releases a reference to the predictor pool. When the last reference is released,
+        /// the pool is disposed to free file handles.
+        /// </summary>
+        private static void ReleasePredictorPool()
+        {
+            lock (ChronologerLock)
+            {
+                _predictorPoolRefCount--;
+                if (_predictorPoolRefCount <= 0)
+                {
+                    DisposePredictorPoolUnsafe();
+                    _predictorPoolRefCount = 0;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Disposes the predictor pool without locking. Must be called within ChronologerLock.
+        /// </summary>
+        private static void DisposePredictorPoolUnsafe()
+        {
+            if (_sharedPredictorPool != null)
+            {
+                foreach (var predictor in _sharedPredictorPool)
+                {
+                    (predictor as IDisposable)?.Dispose();
+                }
+                _sharedPredictorPool = null;
+            }
+        }
 
         // Then update the BatchCalculateRetentionTimesChronologer method:
         private double[] BatchCalculateRetentionTimesChronologer(List<PeptideWithSetModifications> peptides)
         {
             var results = new double[peptides.Count];
 
-            // Synchronize access to prevent concurrent file access to model
-            lock (ChronologerLock)
-            {
-                var rtPredictor = new Chromatography.RetentionTimePrediction.Chronologer.ChronologerRetentionTimePredictor();
+            if (peptides.Count == 0) return results;
 
-                for (int i = 0; i < peptides.Count; i++)
-                {
-                    var result = rtPredictor.PredictRetentionTime(peptides[i], out var failureReason);
-                    results[i] = result ?? -1;
-                }
+            int threadCount = Math.Min(Environment.ProcessorCount, peptides.Count);
+            if (threadCount < 1) threadCount = 1;
+
+            // Get shared predictor pool (thread-safe creation)
+            var predictorPool = GetOrCreatePredictorPool(threadCount);
+
+            // Atomic counter to assign unique predictor indices to each worker thread
+            int nextPredictorIndex = -1;
+
+            try
+            {
+                // Run predictions in parallel - each worker gets a unique predictor via atomic counter
+                Parallel.For(0, peptides.Count,
+                    new ParallelOptions { MaxDegreeOfParallelism = threadCount },
+                    // Thread-local init: atomically claim a unique predictor index for this worker
+                    () => Interlocked.Increment(ref nextPredictorIndex) % threadCount,
+                    // Body: use the assigned predictor (no lock needed - each worker has exclusive access)
+                    (i, loopState, predictorIndex) =>
+                    {
+                        var result = predictorPool[predictorIndex].PredictRetentionTime(peptides[i], out _);
+                        results[i] = result ?? -1;
+                        return predictorIndex;
+                    },
+                    // Finalizer: nothing to clean up
+                    _ => { }
+                );
+            }
+            finally
+            {
+                // Release reference to allow cleanup when all callers are done
+                ReleasePredictorPool();
             }
 
             return results;
@@ -266,19 +345,23 @@ namespace Tasks
         /// <returns>Array of hydrophobicity values in the same order as input peptides</returns>
         private double[] BatchCalculateHydrophobicity(List<PeptideWithSetModifications> peptides)
         {
-            // Initialize the retention time predictor
-            // TODO: Replace with batch-based ML model (e.g., Prosit, DeepLC, Chronologer)
-            var rtPredictor = new SSRCalc3("SSRCalc 3.0 (300A)", SSRCalc3.Column.A300);
-    
             var results = new double[peptides.Count];
-    
-            // Current implementation: calculate one-by-one
-            // Future implementation: send entire batch to ML model
-            for (int i = 0; i < peptides.Count; i++)
-            {
-                results[i] = rtPredictor.ScoreSequence(peptides[i]);
-            }
-    
+
+            // Use Parallel.For with thread-local SSRCalc3 instances for thread safety
+            // SSRCalc3 is stateless for scoring, so each thread can have its own instance
+            Parallel.For(0, peptides.Count,
+                // Thread-local initialization: create a new SSRCalc3 instance per thread
+                () => new SSRCalc3("SSRCalc 3.0 (300A)", SSRCalc3.Column.A300),
+                // Body: calculate hydrophobicity using thread-local predictor
+                (i, loopState, rtPredictor) =>
+                {
+                    results[i] = rtPredictor.ScoreSequence(peptides[i]);
+                    return rtPredictor;
+                },
+                // Finalizer: nothing to dispose
+                (rtPredictor) => { }
+            );
+
             return results;
         }
 
@@ -291,36 +374,53 @@ namespace Tasks
         private double[] BatchCalculateElectrophoreticMobility(List<PeptideWithSetModifications> peptides)
         {
             var results = new double[peptides.Count];
-    
-            // Can be parallelized if needed for large datasets
-            for (int i = 0; i < peptides.Count; i++)
+
+            // Parallelized for large datasets - GetCifuentesMobility is thread-safe (static, no shared state)
+            Parallel.For(0, peptides.Count, i =>
             {
                 results[i] = GetCifuentesMobility(peptides[i]);
-            }
-    
+            });
+
             return results;
         }
         //calculate electrophoretic mobility of a peptide
         private static double GetCifuentesMobility(PeptideWithSetModifications pwsm)
         {
-            int charge = 1 + pwsm.BaseSequence.Count(f => f == 'K') + pwsm.BaseSequence.Count(f => f == 'R') + pwsm.BaseSequence.Count(f => f == 'H') - CountModificationsThatShiftMobility(pwsm.AllModsOneIsNterminus.Values.AsEnumerable());// the 1 + is for N-terminal
+            // Count K, R, H in a single pass through the sequence (instead of 3 separate LINQ calls)
+            int kCount = 0, rCount = 0, hCount = 0;
+            foreach (char c in pwsm.BaseSequence)
+            {
+                switch (c)
+                {
+                    case 'K': kCount++; break;
+                    case 'R': rCount++; break;
+                    case 'H': hCount++; break;
+                }
+            }
+
+            int charge = 1 + kCount + rCount + hCount - CountModificationsThatShiftMobility(pwsm.AllModsOneIsNterminus.Values);
 
             double mobility = (Math.Log(1 + 0.35 * (double)charge)) / Math.Pow(pwsm.MonoisotopicMass, 0.411);
-            if (Double.IsNaN(mobility)==true)
+            if (Double.IsNaN(mobility))
             {
                 mobility = 0;
             }
             return mobility;
         }
-
+        // Static HashSet for O(1) lookup - created once, reused for all calls
+        private static readonly HashSet<string> ShiftingModifications = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "Acetylation", "Ammonia loss", "Carbamyl", "Deamidation", "Formylation",
+            "N2-acetylarginine", "N6-acetyllysine", "N-acetylalanine", "N-acetylaspartate",
+            "N-acetylcysteine", "N-acetylglutamate", "N-acetylglycine", "N-acetylisoleucine",
+            "N-acetylmethionine", "N-acetylproline", "N-acetylserine", "N-acetylthreonine",
+            "N-acetyltyrosine", "N-acetylvaline", "Phosphorylation", "Phosphoserine",
+            "Phosphothreonine", "Phosphotyrosine", "Sulfonation"
+        };
         public static int CountModificationsThatShiftMobility(IEnumerable<Modification> modifications)
         {
-            List<string> shiftingModifications = new List<string> { "Acetylation", "Ammonia loss", "Carbamyl", "Deamidation", "Formylation",
-                "N2-acetylarginine", "N6-acetyllysine", "N-acetylalanine", "N-acetylaspartate", "N-acetylcysteine", "N-acetylglutamate", "N-acetylglycine",
-                "N-acetylisoleucine", "N-acetylmethionine", "N-acetylproline", "N-acetylserine", "N-acetylthreonine", "N-acetyltyrosine", "N-acetylvaline",
-                "Phosphorylation", "Phosphoserine", "Phosphothreonine", "Phosphotyrosine", "Sulfonation" };
-
-            return modifications.Select(n => n.OriginalId).Intersect(shiftingModifications).Count();
+            return modifications.Count(mod =>
+                mod.OriginalId != null && ShiftingModifications.Contains(mod.OriginalId));
         }
         /// <summary>
         /// Calculates protein sequence coverage for each protease across all databases.

--- a/Tasks/DigestionTask.cs
+++ b/Tasks/DigestionTask.cs
@@ -729,36 +729,31 @@ namespace Tasks
                        
             
             var numberOfPeptides = allPeptides.Count();
-            double numberOfFiles = Math.Ceiling(numberOfPeptides / 1000000.0);
-            var peptidesInFile = 1;
+            const int peptidesPerFile = 1000000;
+            double numberOfFiles = (int)Math.Ceiling(numberOfPeptides / (double)peptidesPerFile);
             var peptideIndex = 0;
-            var fileCount = 1;           
 
-                while (fileCount <= Convert.ToInt32(numberOfFiles))
+            for (int fileCount = 1; fileCount <= numberOfFiles; fileCount++)
+            {
+                string outputPath = Path.Combine(filePath, $"ProteaseGuruPeptides_{fileCount}.tsv");
+                using (StreamWriter output = new StreamWriter(outputPath))
                 {
-                    using (StreamWriter output = new StreamWriter(filePath + @"\ProteaseGuruPeptides_" + fileCount + ".tsv"))
+                    output.WriteLine(header);
+
+                    int peptdesWrittenToThisFile = 0;
+                    while (peptdesWrittenToThisFile < peptidesPerFile && peptideIndex < numberOfPeptides)
                     {
-                        output.WriteLine(header);
-                        while (peptidesInFile < 1000000)
-                        {
-                            if (peptideIndex < numberOfPeptides)
-                            {
-                                output.WriteLine(allPeptides[peptideIndex].ToString());
-                                peptideIndex++;
-                            }                            
-                            peptidesInFile++;
-                                                        
-                        }
-                        output.Close();
-                        peptidesInFile = 1;
-                    }                    
-                    fileCount++;
+                        output.WriteLine(allPeptides[peptideIndex].ToString());
+                        peptideIndex++;
+                        peptdesWrittenToThisFile++;
+                    }
                 }
+            }
 
             List<string> parameters = new List<string>();
             parameters.Add("Digestion Conditions:");
             parameters.Add("Database: " + string.Join(',', peptideByFile.Keys));
-            parameters.Add("Proteases: " + string.Join(',', userParams.ProteasesForDigestion.Select(p => p.Name).ToList()));
+            parameters.Add("Proteases: " + string.Join(", ", userParams.ProteasesForDigestion.Select(p => p.Name)));
             parameters.Add("Max Missed Cleavages: " + userParams.NumberOfMissedCleavagesAllowed);
             parameters.Add("Min Peptide Length: " + userParams.MinPeptideLengthAllowed);
             parameters.Add("Max Peptide Length: " + userParams.MaxPeptideLengthAllowed);
@@ -778,9 +773,9 @@ namespace Tasks
         //digest proteins for each database using the protease and settings provided
         protected Dictionary<Protein, List<PeptideWithSetModifications>> DigestDatabase(List<Protein> proteinsFromDatabase,
             Protease protease, Parameters userDigestionParams)
-        {           
+        {
             DigestionParams dp = new DigestionParams(protease: protease.Name, maxMissedCleavages: userDigestionParams.NumberOfMissedCleavagesAllowed,
-                minPeptideLength: userDigestionParams.MinPeptideLengthAllowed, maxPeptideLength: userDigestionParams.MaxPeptideLengthAllowed);            
+                minPeptideLength: userDigestionParams.MinPeptideLengthAllowed, maxPeptideLength: userDigestionParams.MaxPeptideLengthAllowed);
             Dictionary<Protein, List<PeptideWithSetModifications>> peptidesForProtein = new Dictionary<Protein, List<PeptideWithSetModifications>>(proteinsFromDatabase.Count);
             foreach (var protein in proteinsFromDatabase)
             {

--- a/Tasks/DigestionTask.cs
+++ b/Tasks/DigestionTask.cs
@@ -77,7 +77,7 @@ namespace Tasks
             Status("Writing Results Summary...", "summary");
 
             return myRunResults;
-        } 
+        }
         // Load proteins from XML or FASTA databases and keep them associated with the database file name from which they came from
         protected List<Protein> LoadProteins(DbForDigestion database)
         {                        

--- a/Tasks/DigestionTask.cs
+++ b/Tasks/DigestionTask.cs
@@ -13,9 +13,8 @@ namespace Tasks
     //digest the provided databases with the proteases and parameters provided by the user
     public class DigestionTask : ProteaseGuruTask
     {
-        // Shared concurrency limiter for all parallel operations in this task
+        // Maximum concurrency for parallel operations
         private static readonly int MaxConcurrency = Environment.ProcessorCount;
-        private SemaphoreSlim? _concurrencyLimiter;
 
         public DigestionTask(): base(MyTask.Digestion)
         { 
@@ -35,9 +34,6 @@ namespace Tasks
         {
             AllPeptidesByProtease = new Dictionary<string, Dictionary<Protein, List<InSilicoPep>>>();
             PeptideByFile = new Dictionary<string, Dictionary<string, Dictionary<Protein, List<InSilicoPep>>>>(dbFileList.Count);
-
-            // Initialize concurrency limiter for this run
-            _concurrencyLimiter = new SemaphoreSlim(MaxConcurrency, MaxConcurrency);
 
             // Use a thread-safe dictionary for parallel writes
             var concurrentPeptideByFile = new ConcurrentDictionary<string, ConcurrentDictionary<string, Dictionary<Protein, List<InSilicoPep>>>>();
@@ -246,8 +242,8 @@ namespace Tasks
 
             return inSilicoPeptides;
         }
-        // Replace the existing predictor pool implementation (lines ~227-280) with this:
-        
+
+        //Shared Chronologer predictor pool and synchronization primitives for thread-safe access across all parallel workers
         private static readonly object ChronologerLock = new object();
         private static ConcurrentBag<ChronologerRetentionTimePredictor> _predictorPool;
         private static int _poolSize;
@@ -367,10 +363,9 @@ namespace Tasks
             var results = new double[peptides.Count];
             if (peptides.Count == 0) return results;
 
-            // Use limited parallelism to avoid oversubscription
             var options = new ParallelOptions 
             { 
-                MaxDegreeOfParallelism = Math.Max(1, _concurrencyLimiter?.CurrentCount ?? MaxConcurrency) 
+                MaxDegreeOfParallelism = MaxConcurrency 
             };
 
             Parallel.For(0, peptides.Count,
@@ -398,10 +393,9 @@ namespace Tasks
             var results = new double[peptides.Count];
             if (peptides.Count == 0) return results;
 
-            // Use limited parallelism to avoid oversubscription
             var options = new ParallelOptions 
             { 
-                MaxDegreeOfParallelism = Math.Max(1, _concurrencyLimiter?.CurrentCount ?? MaxConcurrency) 
+                MaxDegreeOfParallelism = MaxConcurrency 
             };
 
             Parallel.For(0, peptides.Count, options, i =>

--- a/Tasks/DigestionTask.cs
+++ b/Tasks/DigestionTask.cs
@@ -13,6 +13,10 @@ namespace Tasks
     //digest the provided databases with the proteases and parameters provided by the user
     public class DigestionTask : ProteaseGuruTask
     {
+        // Shared concurrency limiter for all parallel operations in this task
+        private static readonly int MaxConcurrency = Environment.ProcessorCount;
+        private SemaphoreSlim _concurrencyLimiter;
+
         public DigestionTask(): base(MyTask.Digestion)
         { 
           DigestionParameters = new Parameters();
@@ -32,11 +36,20 @@ namespace Tasks
             AllPeptidesByProtease = new Dictionary<string, Dictionary<Protein, List<InSilicoPep>>>();
             PeptideByFile = new Dictionary<string, Dictionary<string, Dictionary<Protein, List<InSilicoPep>>>>(dbFileList.Count);
 
+            // Initialize concurrency limiter for this run
+            _concurrencyLimiter = new SemaphoreSlim(MaxConcurrency, MaxConcurrency);
+
             // Use a thread-safe dictionary for parallel writes
             var concurrentPeptideByFile = new ConcurrentDictionary<string, ConcurrentDictionary<string, Dictionary<Protein, List<InSilicoPep>>>>();
 
-            // Process each database in parallel
-            Parallel.ForEach(dbFileList, database =>
+            // Limit outer parallelism to avoid oversubscription with inner parallel loops
+            var outerParallelOptions = new ParallelOptions 
+            { 
+                MaxDegreeOfParallelism = Math.Max(1, MaxConcurrency / 2) 
+            };
+
+            // Process each database in parallel (limited)
+            Parallel.ForEach(dbFileList, outerParallelOptions, database =>
             {
                 Status("Loading Protein Database(s)...", "loadDbs");
                 List<Protein> proteins = LoadProteins(database);
@@ -49,17 +62,17 @@ namespace Tasks
                 string databaseFileName = database.FileName;
                 List<Protein> proteinsForDigestion = proteins;
 
-                // Process each protease in parallel for this database
-                Parallel.ForEach(DigestionParameters.ProteasesForDigestion, protease =>
+                // Process each protease sequentially within each database
+                // (inner batch methods handle parallelism)
+                foreach (var protease in DigestionParameters.ProteasesForDigestion)
                 {
                     Status("Digesting Proteins...", "digestDbs");
 
                     var peptides = DigestDatabase(proteinsForDigestion, protease, DigestionParameters);
                     var peptidesFormatted = DeterminePeptideStatus(databaseFileName, peptides, DigestionParameters);
 
-                    // Thread-safe add to the concurrent dictionary
                     proteaseResults[protease.Name] = peptidesFormatted;
-                });
+                }
             });
 
             // Convert concurrent dictionary back to regular dictionary
@@ -352,19 +365,22 @@ namespace Tasks
         private double[] BatchCalculateHydrophobicity(List<PeptideWithSetModifications> peptides)
         {
             var results = new double[peptides.Count];
+            if (peptides.Count == 0) return results;
 
-            // Use Parallel.For with thread-local SSRCalc3 instances for thread safety
-            // SSRCalc3 is stateless for scoring, so each thread can have its own instance
+            // Use limited parallelism to avoid oversubscription
+            var options = new ParallelOptions 
+            { 
+                MaxDegreeOfParallelism = Math.Max(1, _concurrencyLimiter?.CurrentCount ?? MaxConcurrency) 
+            };
+
             Parallel.For(0, peptides.Count,
-                // Thread-local initialization: create a new SSRCalc3 instance per thread
+                options,
                 () => new SSRCalc3("SSRCalc 3.0 (300A)", SSRCalc3.Column.A300),
-                // Body: calculate hydrophobicity using thread-local predictor
                 (i, loopState, rtPredictor) =>
                 {
                     results[i] = rtPredictor.ScoreSequence(peptides[i]);
                     return rtPredictor;
                 },
-                // Finalizer: nothing to dispose
                 (rtPredictor) => { }
             );
 
@@ -380,9 +396,15 @@ namespace Tasks
         private double[] BatchCalculateElectrophoreticMobility(List<PeptideWithSetModifications> peptides)
         {
             var results = new double[peptides.Count];
+            if (peptides.Count == 0) return results;
 
-            // Parallelized for large datasets - GetCifuentesMobility is thread-safe (static, no shared state)
-            Parallel.For(0, peptides.Count, i =>
+            // Use limited parallelism to avoid oversubscription
+            var options = new ParallelOptions 
+            { 
+                MaxDegreeOfParallelism = Math.Max(1, _concurrencyLimiter?.CurrentCount ?? MaxConcurrency) 
+            };
+
+            Parallel.For(0, peptides.Count, options, i =>
             {
                 results[i] = GetCifuentesMobility(peptides[i]);
             });

--- a/Test/DigestionTests.cs
+++ b/Test/DigestionTests.cs
@@ -10,15 +10,15 @@ namespace Test
     public class DigestionTests : IDisposable
     {
         // Named mutex for cross-process synchronization of Chronologer file access
-        private const string ChronologerMutexName = "Global\\ProteaseGuru_Chronologer_Mutex";
-        private ChronologerMutexLock _mutexLock;
+        private const string ChronologerMutexName = "Local\\ProteaseGuru_Chronologer_Mutex";
+        private ChronologerMutexLock? _mutexLock;
 
         /// <summary>
         /// Disposable wrapper for Chronologer mutex acquisition and release
         /// </summary>
         private sealed class ChronologerMutexLock : IDisposable
         {
-            private Mutex _mutex;
+            private Mutex? _mutex;
             private bool _owned;
 
             public static ChronologerMutexLock Acquire(string mutexName, TimeSpan timeout)

--- a/Test/DigestionTests.cs
+++ b/Test/DigestionTests.cs
@@ -126,7 +126,7 @@ namespace Test
                 }
                 catch (IOException) when (attempt < maxRetries - 1)
                 {
-                    // Brief delay to allow file handles to be released
+                    // Retry with delay after I/O exception
                     Thread.Sleep(delayMs);
                 }
                 catch (UnauthorizedAccessException) when (attempt < maxRetries - 1)

--- a/Test/DigestionTests.cs
+++ b/Test/DigestionTests.cs
@@ -1,12 +1,7 @@
 using Engine;
 using NUnit.Framework;
 using Proteomics.ProteolyticDigestion;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using Tasks;
-using UsefulProteomicsDatabases;
 
 namespace Test
 {

--- a/Test/DigestionTests.cs
+++ b/Test/DigestionTests.cs
@@ -6,9 +6,85 @@ using Tasks;
 namespace Test
 {
     [TestFixture]
-    [NonParallelizable] // Prevent parallel execution due to shared Chronologer model file
-    public class DigestionTests
+    [NonParallelizable]
+    public class DigestionTests : IDisposable
     {
+        // Named mutex for cross-process synchronization of Chronologer file access
+        private const string ChronologerMutexName = "Global\\ProteaseGuru_Chronologer_Mutex";
+        private ChronologerMutexLock _mutexLock;
+
+        /// <summary>
+        /// Disposable wrapper for Chronologer mutex acquisition and release
+        /// </summary>
+        private sealed class ChronologerMutexLock : IDisposable
+        {
+            private Mutex _mutex;
+            private bool _owned;
+
+            public static ChronologerMutexLock Acquire(string mutexName, TimeSpan timeout)
+            {
+                var lockObj = new ChronologerMutexLock();
+                lockObj._mutex = new Mutex(false, mutexName);
+
+                try
+                {
+                    lockObj._owned = lockObj._mutex.WaitOne(timeout);
+                    if (!lockObj._owned)
+                    {
+                        lockObj._mutex.Dispose();
+                        lockObj._mutex = null;
+                        throw new TimeoutException($"Timed out waiting for mutex: {mutexName}");
+                    }
+                }
+                catch (AbandonedMutexException)
+                {
+                    // Previous owner terminated without releasing - mutex is still acquired
+                    lockObj._owned = true;
+                    TestContext.WriteLine("Warning: Acquired abandoned Chronologer mutex from a crashed process");
+                }
+                catch when (lockObj._mutex != null)
+                {
+                    lockObj._mutex.Dispose();
+                    lockObj._mutex = null;
+                    throw;
+                }
+
+                return lockObj;
+            }
+
+            public void Dispose()
+            {
+                if (_mutex != null)
+                {
+                    if (_owned)
+                    {
+                        try { _mutex.ReleaseMutex(); }
+                        catch (ApplicationException) { /* Not owned by this thread */ }
+                    }
+                    _mutex.Dispose();
+                    _mutex = null;
+                }
+            }
+        }
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mutexLock = ChronologerMutexLock.Acquire(ChronologerMutexName, TimeSpan.FromMinutes(5));
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _mutexLock?.Dispose();
+            _mutexLock = null;
+        }
+
+        public void Dispose()
+        {
+            _mutexLock?.Dispose();
+        }
+
         /// <summary>
         /// Helper method to find a peptide by its base sequence
         /// </summary>
@@ -45,13 +121,12 @@ namespace Test
             {
                 try
                 {
-                    GC.Collect();
-                    GC.WaitForPendingFinalizers();
                     Directory.Delete(folderPath, true);
                     return;
                 }
                 catch (IOException) when (attempt < maxRetries - 1)
                 {
+                    // Brief delay to allow file handles to be released
                     Thread.Sleep(delayMs);
                 }
                 catch (UnauthorizedAccessException) when (attempt < maxRetries - 1)
@@ -67,7 +142,7 @@ namespace Test
         }
 
         [Test]
-        public static void SingleDatabase()
+        public void SingleDatabase()
         {
             string subFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, $"DigestionTest_{Guid.NewGuid():N}");
             Directory.CreateDirectory(subFolder);
@@ -132,7 +207,7 @@ namespace Test
         }
 
         [Test]
-        public static void MultipleDatabases()
+        public void MultipleDatabases()
         {
             string subFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, $"DigestionTest_{Guid.NewGuid():N}");
             Directory.CreateDirectory(subFolder);
@@ -177,7 +252,7 @@ namespace Test
         }
 
         [Test]
-        public static void ProteaseModTest()
+        public void ProteaseModTest()
         {
             string subFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, $"DigestionTest_{Guid.NewGuid():N}");
             Directory.CreateDirectory(subFolder);
@@ -219,7 +294,7 @@ namespace Test
         }
 
         [Test]
-        public static void InitiatorMethionineTest()
+        public void InitiatorMethionineTest()
         {
             string subFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, $"DigestionTest_{Guid.NewGuid():N}");
             Directory.CreateDirectory(subFolder);


### PR DESCRIPTION
This pull request refactors the protein digestion summary display in the GUI, replacing the previous hierarchical tree view with a tabular DataGrid for improved clarity and usability. It also updates the export logic to match the new table structure and introduces a new data model for summary rows. Additionally, the `DigestionTests` class is enhanced with robust cross-process synchronization to prevent file access conflicts during test execution.

**GUI Refactor: Protein Digestion Summary Display**

* Replaced the hierarchical `TreeView` in `ProteinResultsWindow.xaml` with a `DataGrid` that presents digestion summary data in a flat, readable table format, including columns for protease, peptide counts, and coverage metrics.
* Updated the logic in `ProteinResultsWindow.xaml.cs` to build and bind a list of `ProteinDigestionSummaryRow` objects to the DataGrid, streamlining the summary construction and display.
* Introduced the `ProteinDigestionSummaryRow` class to encapsulate summary data for each protease, supporting the new DataGrid structure.

**Export and Data Handling Improvements**

* Modified export functionality to output the new tabular summary format, ensuring exported files reflect the DataGrid structure and content.
* Cleaned up unused tree view-related fields and initialization code in `ProteinResultsWindow.xaml.cs`. [[1]](diffhunk://#diff-2113e9b9e0af3783c524da9fab6f57d111abc891e123c4f6e8cdc27afaee65adL42-L46) [[2]](diffhunk://#diff-2113e9b9e0af3783c524da9fab6f57d111abc891e123c4f6e8cdc27afaee65adL127)

**Testing Enhancements**

* Added a disposable mutex lock in `DigestionTests.cs` to synchronize access to the Chronologer model file across test processes, preventing race conditions and file corruption.
* Updated test method signatures and folder cleanup logic for improved reliability and compatibility with the new mutex-based synchronization. [[1]](diffhunk://#diff-834fb06eed19612aa41ad184b8e0b19a53448eaf9c096ec5100d9911ef28ae72L53-R129) [[2]](diffhunk://#diff-834fb06eed19612aa41ad184b8e0b19a53448eaf9c096ec5100d9911ef28ae72L75-R145) [[3]](diffhunk://#diff-834fb06eed19612aa41ad184b8e0b19a53448eaf9c096ec5100d9911ef28ae72L140-R210)

**Coverage Calculation Consistency**

* Adjusted `CalculateSequenceCoverageUnique` in `ProteinCoverageAnalyzer.cs` to return unrounded coverage fractions, delegating rounding to the display layer for consistency across the GUI and exports. [[1]](diffhunk://#diff-a628b21829d80fef8371977d13ebdb5d55c34baf8ab1c99decee7947536f962dL170-R170) [[2]](diffhunk://#diff-a628b21829d80fef8371977d13ebdb5d55c34baf8ab1c99decee7947536f962dL196-R198)