### PR TITLE
update to mzLib 579

### DIFF
--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="mzLib" Version="1.0.578" />
+        <PackageReference Include="mzLib" Version="1.0.579" />
         <PackageReference Include="TopDownProteomics" Version="0.0.298" />
     </ItemGroup>
 

--- a/GUI/GUI.csproj
+++ b/GUI/GUI.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="mzLib" Version="1.0.578" />
+    <PackageReference Include="mzLib" Version="1.0.579" />
     <PackageReference Include="Nett" Version="0.15.0" />
     <PackageReference Include="OxyPlot.Core" Version="2.2.0" />
     <PackageReference Include="OxyPlot.SkiaSharp" Version="2.2.0" />

--- a/GuiFunctions/GuiFunctions.csproj
+++ b/GuiFunctions/GuiFunctions.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="mzLib" Version="1.0.578" />
+    <PackageReference Include="mzLib" Version="1.0.579" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tasks/DigestionTask.cs
+++ b/Tasks/DigestionTask.cs
@@ -380,7 +380,7 @@ namespace Tasks
                     var predictor = CheckoutPredictor();
                     try
                     {
-                        var result = predictor.PredictRetentionTime(peptides[i], out _);
+                        var result = predictor.PredictRetentionTimeEquivalent(peptides[i], out _);
                         results[i] = result ?? -1;
                     }
                     finally

--- a/Tasks/Tasks.csproj
+++ b/Tasks/Tasks.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="mzLib" Version="1.0.578" />
+    <PackageReference Include="mzLib" Version="1.0.579" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>
 

--- a/Test/ChronologerTests.cs
+++ b/Test/ChronologerTests.cs
@@ -123,7 +123,7 @@ internal class ChronologerTests
                     continue;
                 }
 
-                var result = rtPredictor.PredictRetentionTime(peptide, out var failureReason);
+                var result = rtPredictor.PredictRetentionTimeEquivalent(peptide, out var failureReason);
 
                 if (result.HasValue)
                 {
@@ -192,8 +192,8 @@ internal class ChronologerTests
 
             for (int i = 0; i < validPeptides.Count; i++)
             {
-                var result1 = rtPredictor.PredictRetentionTime(validPeptides[i], out var failureReason1);
-                var result2 = rtPredictor.PredictRetentionTime(validPeptides[i], out var failureReason2);
+                var result1 = rtPredictor.PredictRetentionTimeEquivalent(validPeptides[i], out var failureReason1);
+                var result2 = rtPredictor.PredictRetentionTimeEquivalent(validPeptides[i], out var failureReason2);
 
                 results1[i] = result1 ?? -1;
                 results2[i] = result2 ?? -1;

--- a/Test/Test.csproj
+++ b/Test/Test.csproj
@@ -16,7 +16,7 @@
 
 <ItemGroup>
   <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-  <PackageReference Include="mzLib" Version="1.0.578" />
+  <PackageReference Include="mzLib" Version="1.0.579" />
   <PackageReference Include="Nett" Version="0.15.0" />
   <PackageReference Include="NUnit" Version="4.4.0" />
   <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />


### PR DESCRIPTION
This pull request primarily updates the `mzLib` package dependency to version `1.0.579` across multiple projects and replaces calls to the `PredictRetentionTime` method with `PredictRetentionTimeEquivalent` in both code and tests. These changes ensure compatibility with the latest `mzLib` API and maintain consistency throughout the codebase.

**Dependency updates:**
* Updated the `mzLib` package reference from version `1.0.578` to `1.0.579` in the following project files: `Engine.csproj`, `GUI.csproj`, `GuiFunctions.csproj`, `Tasks.csproj`, and `Test.csproj`. [[1]](diffhunk://#diff-f8c09aff2ccc658b9d0f98d481402b987b6963b8f0be834f9d524b0e4cb7f1c6L9-R9) [[2]](diffhunk://#diff-b71fc64e51682f0b2423cfacd8b9aeb58c21c836dd469ecf5b1cc3c5a233d1ccL11-R11) [[3]](diffhunk://#diff-e804413a2474b8043df189e6974d120b67bdebfee892e6b827c3370582d53d48L10-R10) [[4]](diffhunk://#diff-626776ad8d95a496d665b3a6ee98d3bc58cccab972a922af24a05194f3e30434L20-R20) [[5]](diffhunk://#diff-6b9b9b4014ccddab8742d8a21f7e7aaab4319ee3eee5a6ab04fde717c522e547L19-R19)

**API usage updates:**
* Replaced all usages of `PredictRetentionTime` with `PredictRetentionTimeEquivalent` in the main code (`DigestionTask.cs`) and test files (`ChronologerTests.cs`) to align with the updated `mzLib` API. [[1]](diffhunk://#diff-2eba37cd0658b753a16f969d7527d1fa6eeaa488a94b1736940e2a70a3efa448L383-R383) [[2]](diffhunk://#diff-0e30a98b2f965a1e96eac34f68d5da52cfa6f2624ea7a2a2a2fe86ed136736e5L126-R126) [[3]](diffhunk://#diff-0e30a98b2f965a1e96eac34f68d5da52cfa6f2624ea7a2a2a2fe86ed136736e5L195-R196)